### PR TITLE
Workaround to make pre-releases check green

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -75,7 +75,8 @@ jobs:
       - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
         with:
           dependency_type: pre
-      - run: PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 pip install -e ".[test,dev]"
+          python_version: "3.14"   # TODO: remove once rpds-py supports 3.15
+      - run: pip install -e ".[test,dev]"
       - name: Run the tests
         run: pytest
 


### PR DESCRIPTION
With `PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1` it proceeds to build but fails:

<details>

```
         Compiling base64 v0.22.1
      error[E0432]: unresolved import `pyo3::types::PyDateAccess`
        --> src/input/datetime.rs:7:5
         |
       7 | use pyo3::types::PyDateAccess;
         |     ^^^^^^^^^^^^^^^^^^^^^^^^^ no `PyDateAccess` in `types`
         |
      note: found an item that was configured out
        --> /home/runner/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/pyo3-0.28.2/src/types/mod.rs:12:26
         |
      11 | #[cfg(not(Py_LIMITED_API))]
         |          ---------------- the item is gated here
      12 | pub use self::datetime::{PyDateAccess, PyDeltaAccess, PyTimeAccess};
         |                          ^^^^^^^^^^^^
      
      error[E0432]: unresolved import `pyo3::types::PyTimeAccess`
        --> src/input/datetime.rs:8:5
         |
       8 | use pyo3::types::PyTimeAccess;
         |     ^^^^^^^^^^^^^^^^^^^^^^^^^ no `PyTimeAccess` in `types`
         |
      note: found an item that was configured out
        --> /home/runner/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/pyo3-0.28.2/src/types/mod.rs:12:55
         |
      11 | #[cfg(not(Py_LIMITED_API))]
         |          ---------------- the item is gated here
      12 | pub use self::datetime::{PyDateAccess, PyDeltaAccess, PyTimeAccess};
         |                                                       ^^^^^^^^^^^^
      
      error[E0432]: unresolved import `pyo3::types::PyDeltaAccess`
        --> src/input/datetime.rs:11:48
         |
      11 | use pyo3::types::{PyDate, PyDateTime, PyDelta, PyDeltaAccess, PyDict, PyTime, PyTzInfo};
         |                                                ^^^^^^^^^^^^^ no `PyDeltaAccess` in `types`
         |
      note: found an item that was configured out
        --> /home/runner/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/pyo3-0.28.2/src/types/mod.rs:12:40
         |
      11 | #[cfg(not(Py_LIMITED_API))]
         |          ---------------- the item is gated here
      12 | pub use self::datetime::{PyDateAccess, PyDeltaAccess, PyTimeAccess};
         |                                        ^^^^^^^^^^^^^
      
      error[E0432]: unresolved import `pyo3::types::PyFunction`
        --> src/input/return_enums.rs:14:5
         |
      14 | use pyo3::types::PyFunction;
         |     ^^^^^^^^^^^^^----------
         |     |            |
         |     |            help: a similar name exists in the module: `PyCFunction`
         |     no `PyFunction` in `types`
         |
      note: found an item that was configured out
        --> /home/runner/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/pyo3-0.28.2/src/types/mod.rs:23:25
         |
      22 | #[cfg(not(Py_LIMITED_API))]
         |          ---------------- the item is gated here
      23 | pub use self::function::PyFunction;
         |                         ^^^^^^^^^^
      
      error[E0432]: unresolved import `pyo3::types::PyDeltaAccess`
        --> src/validators/timedelta.rs:6:28
         |
       6 | use pyo3::types::{PyDelta, PyDeltaAccess, PyDict, PyString};
         |                            ^^^^^^^^^^^^^ no `PyDeltaAccess` in `types`
         |
      note: found an item that was configured out
        --> /home/runner/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/pyo3-0.28.2/src/types/mod.rs:12:40
         |
      11 | #[cfg(not(Py_LIMITED_API))]
         |          ---------------- the item is gated here
      12 | pub use self::datetime::{PyDateAccess, PyDeltaAccess, PyTimeAccess};
         |                                        ^^^^^^^^^^^^^
      
      error[E0277]: pyclass `PyTzInfo` cannot be subclassed
         --> src/input/datetime.rs:729:1
          |
      729 | #[pyclass(module = "pydantic_core._pydantic_core", extends = PyTzInfo, frozen, skip_from_py_object)]
          | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required for `#[pyclass(extends=PyTzInfo)]`
          |
          = help: the trait `PyClassBaseType` is not implemented for `PyTzInfo`
          = note: `PyTzInfo` must have `#[pyclass(subclass)]` to be eligible for subclassing
          = note: with the `abi3` feature enabled, PyO3 does not support subclassing native types
          = help: the following other types implement trait `PyClassBaseType`:
                    PyArithmeticError
                    PyAssertionError
                    PyAttributeError
                    PyBaseException
                    PyBaseExceptionGroup
                    PyBlockingIOError
                    PyBrokenPipeError
                    PyBufferError
                  and 69 others
          = note: this error originates in the attribute macro `pyclass` (in Nightly builds, run with -Z macro-backtrace for more info)
      
      error[E0277]: pyclass `PyTzInfo` cannot be subclassed
         --> src/input/datetime.rs:729:62
          |
      729 | #[pyclass(module = "pydantic_core._pydantic_core", extends = PyTzInfo, frozen, skip_from_py_object)]
          |                                                              ^^^^^^^^ required for `#[pyclass(extends=PyTzInfo)]`
          |
          = help: the trait `PyClassBaseType` is not implemented for `PyTzInfo`
          = note: `PyTzInfo` must have `#[pyclass(subclass)]` to be eligible for subclassing
          = note: with the `abi3` feature enabled, PyO3 does not support subclassing native types
          = help: the following other types implement trait `PyClassBaseType`:
                    PyArithmeticError
                    PyAssertionError
                    PyAttributeError
                    PyBaseException
                    PyBaseExceptionGroup
                    PyBlockingIOError
                    PyBrokenPipeError
                    PyBufferError
                  and 69 others
      note: required by a bound in `PyClassImpl::BaseType`
         --> /home/runner/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/pyo3-0.28.2/src/impl_/pyclass.rs:184:33
          |
      184 |     type BaseType: PyTypeInfo + PyClassBaseType;
          |                                 ^^^^^^^^^^^^^^^ required by this bound in `PyClassImpl::BaseType`
      
      Some errors have detailed explanations: E0277, E0432.
      For more information about an error, try `rustc --explain E0277`.
      error: could not compile `pydantic-core` (lib) due to 7 previous errors
      💥 maturin failed

```


</details>


Instead pinning to Python 3.14 temporarily.