### PR TITLE
Build NPM package via releaser

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,11 +72,12 @@ version_cmd = "hatch version"
 [tool.jupyter-releaser.hooks]
 before-build-npm = [
     "node jupyter_builder/yarn.js",
-    "npx tsc",
+    "node jupyter_builder/yarn.js clean:lib",
+    "node jupyter_builder/yarn.js build:lib:prod",
 ]
 before-build-python = [
-    "npx rimraf lib tsconfig.tsbuildinfo",
-    "npx rimraf .eslintcache"
+    "node jupyter_builder/yarn.js clean:lib",
+    "node jupyter_builder/yarn.js clean:lintcache",
 ]
 
 [tool.mypy]


### PR DESCRIPTION
The `jlpm` command used by the releaser hooks isn’t available before the package is installed (since this package provides `jlpm`).  
Replace `jlpm` with the actual `yarn.js` path instead.

```python
[tool.jupyter-releaser.hooks]
before-build-npm = [
    "node jupyter_builder/yarn.js",
    "node jupyter_builder/yarn.js clean:lib",
    "node jupyter_builder/yarn.js build:lib:prod",
]
before-build-python = [
    "node jupyter_builder/yarn.js clean:lib",
    "node jupyter_builder/yarn.js clean:lintcache",
]
```