### PR TITLE
Restore `core-path` flag as mark it as depricated.

### DIFF
--- a/jupyter_builder/extension_commands/build.py
+++ b/jupyter_builder/extension_commands/build.py
@@ -26,6 +26,12 @@ class BuildLabExtensionApp(BaseExtensionApp):
         help="Path to the core application package definition file",
     )
 
+    core_path = Unicode(
+        "",
+        config=True,
+        help="Directory containing core application package.json file"
+    )
+
     core_version = Unicode(
         "",
         config=True,
@@ -39,6 +45,7 @@ class BuildLabExtensionApp(BaseExtensionApp):
         "development": "BuildLabExtensionApp.development",
         "source-map": "BuildLabExtensionApp.source_map",
         "core-package-file": "BuildLabExtensionApp.core_package_file",
+        "core-path": "BuildLabExtensionApp.core_path",
         "core-version": "BuildLabExtensionApp.core_version",
     }
 
@@ -52,6 +59,7 @@ class BuildLabExtensionApp(BaseExtensionApp):
             source_map=self.source_map,
             core_version=self.core_version or None,
             core_package_file=self.core_package_file or None,
+            core_path=self.core_path or None,
         )
 
 

--- a/jupyter_builder/extension_commands/build.py
+++ b/jupyter_builder/extension_commands/build.py
@@ -29,7 +29,7 @@ class BuildLabExtensionApp(BaseExtensionApp):
     core_path = Unicode(
         "",
         config=True,
-        help="Directory containing core application package.json file"
+        help="(Deprecated) Directory containing core application package.json file",
     )
 
     core_version = Unicode(

--- a/jupyter_builder/federated_extensions.py
+++ b/jupyter_builder/federated_extensions.py
@@ -212,7 +212,8 @@ def build_labextension(  # noqa: PLR0913
     if core_path is not None:
         if logger:
             logger.warning(
-                "\033[33m(Deprecated) `core_path` is deprecated and will be removed in a future release. Use `core_package_file` instead.\n \033[0m"
+                "\033[33m(Deprecated) `core_path` is deprecated and will be removed "
+                "in a future release. Use `core_package_file` instead.\n \033[0m"
             )
         core_path_package = Path(core_path).resolve() / "package.json"
         if core_path_package.exists():

--- a/jupyter_builder/federated_extensions.py
+++ b/jupyter_builder/federated_extensions.py
@@ -204,9 +204,20 @@ def build_labextension(  # noqa: PLR0913
     source_map=False,
     core_version=None,
     core_package_file=None,
+    core_path=None,
 ):
     """Build a labextension in the given path"""
     ext_path = str(Path(path).resolve())
+
+    if core_path is not None:
+        if logger:
+            logger.warning(
+                "\033[33m(Deprecated) `core_path` is deprecated and will be removed in a future release. Use `core_package_file` instead.\n \033[0m"
+            )
+        core_path_package = Path(core_path).resolve() / "package.json"
+        if core_path_package.exists():
+            core_package_file = str(core_path_package)
+
     core_package_file = core_package_file or get_core_meta(core_version, ext_path=ext_path)
     core_package_file = str(Path(core_package_file).resolve())
 


### PR DESCRIPTION
### Description
As discussed here https://github.com/jupyterlab/jupyterlab/pull/18723#discussion_r3058999024, some downstream application might be using `core-path`. So marking as depricated in python side.