### PR TITLE
Add `jupyter-core` as a dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Maintenance and upkeep improvements
 
-- Restore `core-path` flag as mark it as depricated. [#73](https://github.com/jupyterlab/jupyter-builder/pull/73) ([@Darshan808](https://github.com/Darshan808), [@krassowski](https://github.com/krassowski))
+- Restore `core-path` flag as mark it as deprecated. [#73](https://github.com/jupyterlab/jupyter-builder/pull/73) ([@Darshan808](https://github.com/Darshan808), [@krassowski](https://github.com/krassowski))
 - Remove `jupyterlab-server` as a dependency [#72](https://github.com/jupyterlab/jupyter-builder/pull/72) ([@Darshan808](https://github.com/Darshan808), [@krassowski](https://github.com/krassowski))
 
 ### Documentation improvements

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
 ]
-dependencies = ["traitlets", "requests"]
+dependencies = ["traitlets", "requests", "jupyter-core"]
 dynamic = ["version"]
 
 [project.urls]
@@ -47,7 +47,7 @@ test = [
     "pytest-cov",
     "copier>=9.3,<10",
     "jinja2-time",
-    "jupyterlab",
+    "jupyterlab"
 ]
 # Check ruff version is aligned with the one in .pre-commit-config.yaml
 dev = ["build", "mypy", "pre-commit", "hatch", "ruff==0.14.14"]


### PR DESCRIPTION
### Description
Identified in the failing action: https://github.com/jupyterlab/jupyterlab/actions/runs/24234580389/job/70753875502?pr=18723
with error:
```
File "/private/var/folders/tb/y368xp_x10s3ty1b_mtl5mxr0000gn/T/pip-build-env-r_9s_1o8/overlay/lib/python3.14/site-packages/jupyter_builder/main.py", line 6, in <module>
  from jupyter_core.application import JupyterApp
ModuleNotFoundError: No module named 'jupyter_core'
```
`jupyter-builder` uses `jupyter_core` but does not declare it as dependency.
https://github.com/jupyterlab/jupyter-builder/blob/c6754b14e38cba51141e5ae4ec918b5bfeb1cc02/jupyter_builder/main.py#L6

But the CI should've failed on #72 
- [ ] Add a test for it.
- [ ] See if we could just import Application from traitlets instead