### PR TITLE
Remove `jupyterlab` from test dependencies and drop `jupyter_sever` usage.

### DIFF
--- a/jupyter_builder/federated_extensions.py
+++ b/jupyter_builder/federated_extensions.py
@@ -23,7 +23,6 @@ from os.path import join as pjoin
 
 from jupyter_core.paths import ENV_JUPYTER_PATH, SYSTEM_JUPYTER_PATH, jupyter_data_dir
 from jupyter_core.utils import ensure_dir_exists
-from jupyter_server.extension.serverextension import ArgumentConflict
 
 from .federated_extensions_requirements import get_federated_extensions
 
@@ -38,6 +37,10 @@ from .core_path import get_core_meta
 DEPRECATED_ARGUMENT = object()
 
 HERE = osp.abspath(osp.dirname(__file__))
+
+
+class ArgumentConflict(ValueError):  # noqa N818
+    pass
 
 
 # ------------------------------------------------------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,8 +46,7 @@ test = [
     "pytest-check-links>=0.7",
     "pytest-cov",
     "copier>=9.3,<10",
-    "jinja2-time",
-    "jupyterlab",
+    "jinja2-time"
 ]
 # Check ruff version is aligned with the one in .pre-commit-config.yaml
 dev = ["build", "mypy", "pre-commit", "hatch", "ruff==0.14.14"]

--- a/tests/test_tpl.py
+++ b/tests/test_tpl.py
@@ -54,7 +54,7 @@ def test_files_build(tmp_path):
         check=True,
         env=env,
     )
-    run(["jlpm", "run", "build:prod"], cwd=extension_folder, check=True)
+    run(["jlpm", "run", "build:lib"], cwd=extension_folder, check=True)
 
     run(["jupyter-builder", "build", str(extension_folder)], cwd=extension_folder, check=True)
 
@@ -86,7 +86,7 @@ def test_files_build_development(tmp_path):
         check=True,
         env=env,
     )
-    run(["jlpm", "run", "build:prod"], cwd=extension_folder, check=True)
+    run(["jlpm", "run", "build:lib"], cwd=extension_folder, check=True)
 
     run(
         ["jupyter-builder", "build", "--development", "true", str(extension_folder)],

--- a/tests/test_tpl.py
+++ b/tests/test_tpl.py
@@ -130,7 +130,7 @@ def test_watch_functionality(tmp_path):
         check=True,
         env=env,
     )
-    run(["jlpm", "run", "build"], cwd=extension_folder, check=True)
+    run(["jlpm", "run", "build:lib"], cwd=extension_folder, check=True)
 
     # Path to the TypeScript file to change
     index_ts_path = extension_folder / "src/index.ts"

--- a/tests/test_tpl.py
+++ b/tests/test_tpl.py
@@ -54,7 +54,7 @@ def test_files_build(tmp_path):
         check=True,
         env=env,
     )
-    run(["jlpm", "run", "build:lib"], cwd=extension_folder, check=True)
+    run(["jlpm", "run", "build:lib:prod"], cwd=extension_folder, check=True)
 
     run(["jupyter-builder", "build", str(extension_folder)], cwd=extension_folder, check=True)
 
@@ -86,7 +86,7 @@ def test_files_build_development(tmp_path):
         check=True,
         env=env,
     )
-    run(["jlpm", "run", "build:lib"], cwd=extension_folder, check=True)
+    run(["jlpm", "run", "build:lib:prod"], cwd=extension_folder, check=True)
 
     run(
         ["jupyter-builder", "build", "--development", "true", str(extension_folder)],
@@ -130,7 +130,7 @@ def test_watch_functionality(tmp_path):
         check=True,
         env=env,
     )
-    run(["jlpm", "run", "build:lib"], cwd=extension_folder, check=True)
+    run(["jlpm", "run", "build:lib:prod"], cwd=extension_folder, check=True)
 
     # Path to the TypeScript file to change
     index_ts_path = extension_folder / "src/index.ts"


### PR DESCRIPTION
### Fixes #77 

### Description

- Remove `jupyterlab` from test dependencies.
- Modify tests to not use `jupyterlab` (as of now the build script has `jupyter labextension`. So don't use build command for now.
- Remove `jupyter_server` usage and declare the imported error locally