### PR TITLE
Fix missing `tomli` dependency for Python < 3.11

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
 ]
-dependencies = ["traitlets", "requests", "jupyter-core"]
+dependencies = ["traitlets", "requests", "jupyter-core", "tomli; python_version < '3.11'"]
 dynamic = ["version"]
 
 [project.urls]


### PR DESCRIPTION
As noticed in https://github.com/jupyter/notebook/pull/7893#issuecomment-4288784413