### PR TITLE
Require Python 3.10+, bump `ruff`

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -22,6 +22,9 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
         python-version: ["3.10", "3.14"]
+        include:
+          - os: ubuntu-latest
+            python-version: "pypy-3.11"
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -22,9 +22,6 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
         python-version: ["3.10", "3.14"]
-        # include:
-        #   - os: ubuntu-latest
-        #     python-version: "pypy-3.8"
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -58,7 +58,7 @@ repos:
           ["traitlets>=5.13"]
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.9.4
+    rev: v0.15.11
     hooks:
       - id: ruff
         types_or: [python, jupyter]

--- a/jupyter_builder/core_path.py
+++ b/jupyter_builder/core_path.py
@@ -139,7 +139,7 @@ def _download_github_core_meta(version: str, destination: Path) -> None:
 
 def _get_installed_core_meta(ext_path: Path) -> str | None:
     if not (ext_path / "node_modules").exists():
-        subprocess.check_call(["jlpm"], cwd=ext_path)  # noqa: S603 S607
+        subprocess.check_call(["jlpm"], cwd=ext_path)  # noqa: S607
 
     target = ext_path
     while True:

--- a/jupyter_builder/core_path.py
+++ b/jupyter_builder/core_path.py
@@ -5,7 +5,6 @@ import os
 import re
 import subprocess
 from pathlib import Path
-from typing import Optional, Union
 
 import requests
 
@@ -16,7 +15,7 @@ def _home_dir() -> Path:
 
 
 def get_core_meta(
-    version: Optional[str] = None, ext_path: Optional[Union[str, os.PathLike[str]]] = None
+    version: str | None = None, ext_path: str | os.PathLike[str] | None = None
 ) -> str:
     requested_version = version
 
@@ -107,7 +106,7 @@ def _resolve_wildcard_npm_version(version: str) -> str:
     return max(matching, key=semver_key)
 
 
-def _get_cached_core_meta_file(cache_root: Path, version: str) -> Optional[Path]:
+def _get_cached_core_meta_file(cache_root: Path, version: str) -> Path | None:
     candidates = [
         cache_root / version / "core.package.json",
         cache_root / version / "package.json",
@@ -138,7 +137,7 @@ def _download_github_core_meta(version: str, destination: Path) -> None:
     destination.write_bytes(r.content)
 
 
-def _get_installed_core_meta(ext_path: Path) -> Optional[str]:
+def _get_installed_core_meta(ext_path: Path) -> str | None:
     if not (ext_path / "node_modules").exists():
         subprocess.check_call(["jlpm"], cwd=ext_path)  # noqa: S603 S607
 

--- a/jupyter_builder/federated_extensions.py
+++ b/jupyter_builder/federated_extensions.py
@@ -97,7 +97,7 @@ def develop_labextension(  # noqa
     # make sure labextensions dir exists
     ensure_dir_exists(labext)
 
-    if isinstance(path, (list, tuple)):
+    if isinstance(path, list | tuple):
         msg = "path must be a string pointing to a single extension to install; call this function multiple times to install multiple extensions"  # noqa: E501
         raise TypeError(msg)
 

--- a/jupyter_builder/federated_extensions.py
+++ b/jupyter_builder/federated_extensions.py
@@ -482,7 +482,7 @@ def _get_labextension_metadata(module):  # noqa
     if not package:
         try:
             package = (
-                subprocess.check_output(  # noqa: S603
+                subprocess.check_output(
                     [sys.executable, "setup.py", "--name"],
                     cwd=mod_path,
                 )
@@ -503,7 +503,7 @@ def _get_labextension_metadata(module):  # noqa
         subprocess.check_call([sys.executable, "-m", "pip", "install", "-e", mod_path])  # noqa S603
         sys.path.insert(0, mod_path)
 
-    from setuptools import find_namespace_packages, find_packages
+    from setuptools import find_namespace_packages, find_packages  # noqa: PLC0415
 
     package_candidates = [
         package.replace("-", "_"),  # Module with the same name as package

--- a/jupyter_builder/jlpm.py
+++ b/jupyter_builder/jlpm.py
@@ -4,6 +4,7 @@
 """A Jupyter-aware wrapper for the yarn package manager"""
 
 import os
+import signal
 import subprocess
 import sys
 from shutil import which
@@ -50,8 +51,6 @@ def _execvp_node(argv):
     """
     cmd = _which_node_js()
     if os.name == "nt":
-        import signal
-
         p = subprocess.Popen([cmd] + argv[1:])  # noqa S603
         # Don't raise KeyboardInterrupt in the parent process.
         # Set this after spawning, to avoid subprocess inheriting handler.

--- a/jupyter_builder/jlpm.py
+++ b/jupyter_builder/jlpm.py
@@ -4,7 +4,6 @@
 """A Jupyter-aware wrapper for the yarn package manager"""
 
 import os
-import signal
 import subprocess
 import sys
 from shutil import which
@@ -51,6 +50,8 @@ def _execvp_node(argv):
     """
     cmd = _which_node_js()
     if os.name == "nt":
+        import signal  # noqa: PLC0415
+
         p = subprocess.Popen([cmd] + argv[1:])  # noqa S603
         # Don't raise KeyboardInterrupt in the parent process.
         # Set this after spawning, to avoid subprocess inheriting handler.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ description = "JupyterLab build tools"
 readme = "README.md"
 license = "BSD-3-Clause AND MIT AND ISC"
 license-files = ["LICENSE", "THIRD_PARTY_LICENSES/*.txt"]
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 authors = [
     { name = "Jupyter Development Team", email = "jupyter@googlegroups.com" },
 ]
@@ -24,11 +24,11 @@ classifiers = [
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
 ]
 dependencies = ["traitlets", "requests", "jupyter-core", "tomli; python_version < '3.11'"]
 dynamic = ["version"]
@@ -83,7 +83,7 @@ before-build-python = [
 ]
 
 [tool.mypy]
-python_version = "3.8"
+python_version = "3.10"
 explicit_package_bases = true
 strict = true
 pretty = true
@@ -115,7 +115,7 @@ xfail_strict = true
 ignore = ["PC111", "PC180", "PY004", "PY007", "RTD100"]
 
 [tool.ruff]
-target-version = "py38"
+target-version = "py310"
 line-length = 100
 
 [tool.ruff.lint]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ test = [
     "jinja2-time"
 ]
 # Check ruff version is aligned with the one in .pre-commit-config.yaml
-dev = ["build", "mypy", "pre-commit", "hatch", "ruff==0.14.14"]
+dev = ["build", "mypy", "pre-commit", "hatch", "ruff==0.15.11"]
 
 [project.scripts]
 jupyter-builder = "jupyter_builder.main:main"
@@ -167,4 +167,5 @@ ignore = ["FBT002", "FBT003"]
     "PLR0915",
     "PLR1714",
     "PLR5501",
+    "RUF059",
 ]


### PR DESCRIPTION
- [x] Require the minimum supported python version as of today.
- [x] Also make a couple of cleanups on the code base as a follow-up to this bump.
- [x] Bump and align `ruff` versions. Closes https://github.com/jupyterlab/jupyter-builder/pull/52
- [x] Restore `pypy` testing