### PR TITLE
Handle both `@jupyter/builder` and `@jupyterlab/builder`

### DIFF
--- a/jupyter_builder/federated_extensions.py
+++ b/jupyter_builder/federated_extensions.py
@@ -301,18 +301,31 @@ def watch_labextension(  # noqa: PLR0913
 # ------------------------------------------------------------------------------
 
 
+# Marker packages an extension may declare to identify its builder, in order
+# of preference.
+_BUILDER_MARKER_CANDIDATES = ("@jupyter/builder", "@jupyterlab/builder")
+
+
 def _ensure_builder(ext_path, core_package_file):
     """Ensure that we can build the extension and return the builder script path"""
-    # Test for compatible dependency on @jupyterlab/builder
     with open(core_package_file) as fid:
         core_data = json.load(fid)
     with open(osp.join(ext_path, "package.json")) as fid:
         ext_data = json.load(fid)
-    dep_version1 = core_data["devDependencies"]["@jupyterlab/builder"]
-    dep_version2 = ext_data.get("devDependencies", {}).get("@jupyterlab/builder")
-    dep_version2 = dep_version2 or ext_data.get("dependencies", {}).get("@jupyterlab/builder")
-    if dep_version2 is None:
-        msg = f"Extensions require a devDependency on @jupyterlab/builder@{dep_version1}"
+
+    # Find which marker package the extension declares. Prefer @jupyter/builder.
+    marker_pkg = None
+    dep_version2 = None
+    for candidate in _BUILDER_MARKER_CANDIDATES:
+        v = ext_data.get("devDependencies", {}).get(candidate)
+        v = v or ext_data.get("dependencies", {}).get(candidate)
+        if v is not None:
+            marker_pkg = candidate
+            dep_version2 = v
+            break
+
+    if marker_pkg is None:
+        msg = f"Extensions require a devDependency on {' or '.join(_BUILDER_MARKER_CANDIDATES)}"
         raise ValueError(msg)
 
     # if we have installed from disk (version is a path), assume we know what
@@ -323,33 +336,39 @@ def _ensure_builder(ext_path, core_package_file):
     if not osp.exists(osp.join(ext_path, "node_modules")):
         subprocess.check_call(["jlpm"], cwd=ext_path)  # noqa S603 S607
 
-    # Find @jupyterlab/builder using node module resolution
-    # We cannot use a script because the script path is a shell script on Windows
+    # Find the marker package in node_modules using node module resolution.
+    # We cannot use a script because the script path is a shell script on Windows.
+    marker_parts = marker_pkg.split("/", 1)
     target = ext_path
-    while not osp.exists(osp.join(target, "node_modules", "@jupyterlab", "builder")):
+    while not osp.exists(osp.join(target, "node_modules", *marker_parts)):
         if osp.dirname(target) == target:
-            msg = "Could not find @jupyterlab/builder"
+            msg = f"Could not find {marker_pkg}"
             raise ValueError(msg)
         target = osp.dirname(target)
 
     # Check for compatible versions
-    overlap = _test_overlap(
-        dep_version1, dep_version2, drop_prerelease1=True, drop_prerelease2=True
-    )
-    if not overlap:
-        with open(
-            osp.join(target, "node_modules", "@jupyterlab", "builder", "package.json")
-        ) as fid:
-            dep_version2 = json.load(fid).get("version")
+    dep_version1 = core_data.get("devDependencies", {}).get(marker_pkg)
+    if dep_version1 is not None:
         overlap = _test_overlap(
             dep_version1, dep_version2, drop_prerelease1=True, drop_prerelease2=True
         )
+        if not overlap:
+            with open(
+                osp.join(target, "node_modules", *marker_parts, "package.json")
+            ) as fid:
+                dep_version2 = json.load(fid).get("version")
+            overlap = _test_overlap(
+                dep_version1, dep_version2, drop_prerelease1=True, drop_prerelease2=True
+            )
 
-    if not overlap:
-        msg = f"Extensions require a devDependency on @jupyterlab/builder@{dep_version1}, you have a dependency on {dep_version2}"  # noqa: E501
-        raise ValueError(msg)
+        if not overlap:
+            msg = (
+                f"Extensions require a devDependency on {marker_pkg}@{dep_version1}, "
+                f"you have a dependency on {dep_version2}"
+            )
+            raise ValueError(msg)
 
-    return osp.join(target, "node_modules", "@jupyter", "builder", "lib", "build-labextension.js")
+    return osp.join(target, "node_modules", *marker_parts, "lib", "build-labextension.js")
 
 
 def _should_copy(src, dest, logger=None):

--- a/jupyter_builder/federated_extensions.py
+++ b/jupyter_builder/federated_extensions.py
@@ -306,6 +306,19 @@ def watch_labextension(  # noqa: PLR0913
 _BUILDER_MARKER_CANDIDATES = ("@jupyter/builder", "@jupyterlab/builder")
 
 
+def _select_builder_marker(ext_data):
+    """Return (marker_pkg, dep_spec) for the builder marker the extension declares.
+
+    Prefers `@jupyter/builder`. Returns (None, None) if neither marker is present.
+    """
+    for candidate in _BUILDER_MARKER_CANDIDATES:
+        v = ext_data.get("devDependencies", {}).get(candidate)
+        v = v or ext_data.get("dependencies", {}).get(candidate)
+        if v is not None:
+            return candidate, v
+    return None, None
+
+
 def _ensure_builder(ext_path, core_package_file):
     """Ensure that we can build the extension and return the builder script path"""
     with open(core_package_file) as fid:
@@ -313,17 +326,7 @@ def _ensure_builder(ext_path, core_package_file):
     with open(osp.join(ext_path, "package.json")) as fid:
         ext_data = json.load(fid)
 
-    # Find which marker package the extension declares. Prefer @jupyter/builder.
-    marker_pkg = None
-    dep_version2 = None
-    for candidate in _BUILDER_MARKER_CANDIDATES:
-        v = ext_data.get("devDependencies", {}).get(candidate)
-        v = v or ext_data.get("dependencies", {}).get(candidate)
-        if v is not None:
-            marker_pkg = candidate
-            dep_version2 = v
-            break
-
+    marker_pkg, dep_version2 = _select_builder_marker(ext_data)
     if marker_pkg is None:
         msg = f"Extensions require a devDependency on {' or '.join(_BUILDER_MARKER_CANDIDATES)}"
         raise ValueError(msg)
@@ -353,9 +356,7 @@ def _ensure_builder(ext_path, core_package_file):
             dep_version1, dep_version2, drop_prerelease1=True, drop_prerelease2=True
         )
         if not overlap:
-            with open(
-                osp.join(target, "node_modules", *marker_parts, "package.json")
-            ) as fid:
+            with open(osp.join(target, "node_modules", *marker_parts, "package.json")) as fid:
                 dep_version2 = json.load(fid).get("version")
             overlap = _test_overlap(
                 dep_version1, dep_version2, drop_prerelease1=True, drop_prerelease2=True

--- a/tests/test_core_path.py
+++ b/tests/test_core_path.py
@@ -291,9 +291,9 @@ def test_ensure_builder_reads_custom_core_package_file(tmp_path):
     ext_path = tmp_path / "ext"
     core_path_dir = tmp_path / "core-meta"
     core_package_file = core_path_dir / "core.package.json"
-    # TODO: Once core starts using new @jupyter/builder, we need to update here.
+    # Exercises the backwards-compatible @jupyterlab/builder path. The returned
+    # builder script path matches the marker the extension declares.
     builder_dir = ext_path / "node_modules" / "@jupyterlab" / "builder"
-    new_builder_dir = ext_path / "node_modules" / "@jupyter" / "builder"
 
     builder_dir.mkdir(parents=True)
     core_path_dir.mkdir()
@@ -306,4 +306,4 @@ def test_ensure_builder_reads_custom_core_package_file(tmp_path):
 
     builder_path = _ensure_builder(str(ext_path), str(core_package_file))
 
-    assert builder_path == str(new_builder_dir / "lib" / "build-labextension.js")
+    assert builder_path == str(builder_dir / "lib" / "build-labextension.js")

--- a/tests/test_tpl.py
+++ b/tests/test_tpl.py
@@ -207,12 +207,9 @@ def test_builder_version_mismatch(tmp_path):
         env=env,
     )
 
-    run(
-        ["jlpm", "add", "-D", "@jupyter/builder"],
-        cwd=extension_folder,
-        check=True,
-        env=env,
-    )
+    # Note: we intentionally do not add `@jupyter/builder` here so that the
+    # extension only declares `@jupyterlab/builder` as the builder marker.
+    # This exercises the backwards-compatible version-check path.
     with pytest.raises(subprocess.CalledProcessError) as excinfo:
         run(
             ["jupyter-builder", "build", str(extension_folder)],


### PR DESCRIPTION
As noticed in https://github.com/jupyter/notebook/pull/7893#discussion_r3122020901