### PR TITLE
Bundle static `js` files and `node_modules` in the python package

### DIFF
--- a/jupyter_builder/federated_extensions.py
+++ b/jupyter_builder/federated_extensions.py
@@ -319,6 +319,11 @@ def _select_builder_marker(ext_data):
     return None, None
 
 
+_BUNDLED_BUILDER_SCRIPT = osp.join(
+    osp.dirname(osp.abspath(__file__)), "static", "lib", "build-labextension.js"
+)
+
+
 def _ensure_builder(ext_path, core_package_file):
     """Ensure that we can build the extension and return the builder script path"""
     with open(core_package_file) as fid:
@@ -330,6 +335,10 @@ def _ensure_builder(ext_path, core_package_file):
     if marker_pkg is None:
         msg = f"Extensions require a devDependency on {' or '.join(_BUILDER_MARKER_CANDIDATES)}"
         raise ValueError(msg)
+
+    # Prefer the bundled static builder shipped with jupyter-builder itself.
+    if osp.exists(_BUNDLED_BUILDER_SCRIPT):
+        return _BUNDLED_BUILDER_SCRIPT
 
     # if we have installed from disk (version is a path), assume we know what
     # we are doing and do not check versions.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,9 @@ path = "jupyter_builder/_version.py"
 [tool.hatch.build.targets.sdist]
 exclude = [".github"]
 
+[tool.hatch.build.targets.wheel]
+artifacts = ["jupyter_builder/static"]
+
 [tool.jupyter-releaser.options]
 version_cmd = "hatch version"
 
@@ -80,6 +83,7 @@ before-build-npm = [
 before-build-python = [
     "node jupyter_builder/yarn.js clean:lib",
     "node jupyter_builder/yarn.js clean:lintcache",
+    "python scripts/build_static.py",
 ]
 
 [tool.mypy]

--- a/scripts/build_static.py
+++ b/scripts/build_static.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python3
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+
 """Build the JS assets and copy lib + node_modules into jupyter_builder/static.
 
 Run this script before building or releasing the Python package:

--- a/scripts/build_static.py
+++ b/scripts/build_static.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+"""Build the JS assets and copy lib + node_modules into jupyter_builder/static.
+
+Run this script before building or releasing the Python package:
+    python scripts/build_static.py
+"""
+
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).parent.parent
+STATIC_DIR = ROOT / "jupyter_builder" / "static"
+
+
+def main() -> None:
+    subprocess.check_call(["node", str(ROOT / "jupyter_builder" / "yarn.js"), "build:lib:prod"])  # noqa S603
+
+    lib_src = ROOT / "lib"
+    node_modules_src = ROOT / "node_modules"
+
+    lib_dst = STATIC_DIR / "lib"
+    node_modules_dst = STATIC_DIR / "node_modules"
+
+    if lib_dst.exists():
+        shutil.rmtree(lib_dst)
+    shutil.copytree(lib_src, lib_dst)
+
+    if node_modules_dst.exists():
+        shutil.rmtree(node_modules_dst)
+    shutil.copytree(node_modules_src, node_modules_dst)
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
### References #81 

### Description

Added scripts to bundle the `lib/` directory together with `node_modules/` into the Python package.

While this works, the packaged `node_modules` includes platform-specific binaries (`binding-darwin-arm64/rspack.darwin-arm64.node` on my macOS).

This means platform-specific wheels per architecture will be required.