### PR TITLE
Patch to fully support `@jupyterlab/builder`

### DIFF
--- a/jupyter_builder/federated_extensions.py
+++ b/jupyter_builder/federated_extensions.py
@@ -242,6 +242,7 @@ def build_labextension(  # noqa: PLR0913
         arguments.append("--development")
     if source_map:
         arguments.append("--source-map")
+
     subprocess.check_call(arguments, cwd=ext_path)  # noqa S603
 
 

--- a/jupyter_builder/federated_extensions.py
+++ b/jupyter_builder/federated_extensions.py
@@ -228,15 +228,14 @@ def build_labextension(  # noqa: PLR0913
     if logger:
         logger.info("Building extension in %s", path)
 
-    builder = _ensure_builder(ext_path, core_package_file)
+    builder, marker_pkg = _ensure_builder(ext_path, core_package_file)
 
-    arguments = [
-        "node",
-        builder,
-        "--core-package-file",
-        core_package_file,
-        ext_path,
-    ]
+    if marker_pkg == "@jupyterlab/builder":
+        core_flag = ["--core-path", str(Path(core_package_file).parent)]
+    else:
+        core_flag = ["--core-package-file", core_package_file]
+
+    arguments = ["node", builder, *core_flag, ext_path]
     if static_url is not None:
         arguments.extend(["--static-url", static_url])
     if development:
@@ -279,15 +278,14 @@ def watch_labextension(  # noqa: PLR0913
             shutil.rmtree(full_dest)
             os.symlink(output_dir, full_dest)
 
-    builder = _ensure_builder(ext_path, core_package_file)
-    arguments = [
-        "node",
-        builder,
-        "--core-package-file",
-        core_package_file,
-        "--watch",
-        ext_path,
-    ]
+    builder, marker_pkg = _ensure_builder(ext_path, core_package_file)
+
+    if marker_pkg == "@jupyterlab/builder":
+        core_flag = ["--core-path", str(Path(core_package_file).parent)]
+    else:
+        core_flag = ["--core-package-file", core_package_file]
+
+    arguments = ["node", builder, *core_flag, "--watch", ext_path]
     if development:
         arguments.append("--development")
     if source_map:
@@ -369,7 +367,9 @@ def _ensure_builder(ext_path, core_package_file):
             )
             raise ValueError(msg)
 
-    return osp.join(target, "node_modules", *marker_parts, "lib", "build-labextension.js")
+    return osp.join(
+        target, "node_modules", *marker_parts, "lib", "build-labextension.js"
+    ), marker_pkg
 
 
 def _should_copy(src, dest, logger=None):

--- a/jupyter_builder/federated_extensions.py
+++ b/jupyter_builder/federated_extensions.py
@@ -231,7 +231,7 @@ def build_labextension(  # noqa: PLR0913
     builder, marker_pkg = _ensure_builder(ext_path, core_package_file)
 
     if marker_pkg == "@jupyterlab/builder":
-        core_flag = ["--core-path", str(Path(core_package_file).parent)]
+        core_flag = ["--core-path", _resolve_core_path_for_jupyterlab_builder(core_package_file)]
     else:
         core_flag = ["--core-package-file", core_package_file]
 
@@ -242,7 +242,6 @@ def build_labextension(  # noqa: PLR0913
         arguments.append("--development")
     if source_map:
         arguments.append("--source-map")
-
     subprocess.check_call(arguments, cwd=ext_path)  # noqa S603
 
 
@@ -281,7 +280,7 @@ def watch_labextension(  # noqa: PLR0913
     builder, marker_pkg = _ensure_builder(ext_path, core_package_file)
 
     if marker_pkg == "@jupyterlab/builder":
-        core_flag = ["--core-path", str(Path(core_package_file).parent)]
+        core_flag = ["--core-path", _resolve_core_path_for_jupyterlab_builder(core_package_file)]
     else:
         core_flag = ["--core-package-file", core_package_file]
 
@@ -302,6 +301,21 @@ def watch_labextension(  # noqa: PLR0913
 # Marker packages an extension may declare to identify its builder, in order
 # of preference.
 _BUILDER_MARKER_CANDIDATES = ("@jupyter/builder", "@jupyterlab/builder")
+
+
+def _resolve_core_path_for_jupyterlab_builder(core_package_file):
+    """Return the core path directory for @jupyterlab/builder.
+
+    @jupyterlab/builder's downstream script expects a file named package.json
+    inside the core path directory. If core_package_file is not named
+    package.json, a copy named package.json is created in the same directory.
+    """
+    core_dir = str(Path(core_package_file).parent)
+    if osp.basename(core_package_file) != "package.json":
+        target = osp.join(core_dir, "package.json")
+        if not osp.exists(target):
+            shutil.copy2(core_package_file, target)
+    return core_dir
 
 
 def _select_builder_marker(ext_data):

--- a/tests/test_core_path.py
+++ b/tests/test_core_path.py
@@ -287,12 +287,31 @@ def test_get_core_meta_latest_uses_npm_latest_and_caches_by_resolved_version(tmp
     )
 
 
-def test_ensure_builder_reads_custom_core_package_file(tmp_path):
+def test_ensure_builder_with_jupyter_builder(tmp_path):
     ext_path = tmp_path / "ext"
     core_path_dir = tmp_path / "core-meta"
     core_package_file = core_path_dir / "core.package.json"
-    # Exercises the backwards-compatible @jupyterlab/builder path. The returned
-    # builder script path matches the marker the extension declares.
+    builder_dir = ext_path / "node_modules" / "@jupyter" / "builder"
+
+    builder_dir.mkdir(parents=True)
+    core_path_dir.mkdir()
+
+    core_package_file.write_text(json.dumps({"devDependencies": {"@jupyter/builder": "^5.0.0"}}))
+    (ext_path / "package.json").write_text(
+        json.dumps({"devDependencies": {"@jupyter/builder": "^5.0.0"}})
+    )
+    (builder_dir / "package.json").write_text(json.dumps({"version": "5.0.0"}))
+
+    builder_path, marker_pkg = _ensure_builder(str(ext_path), str(core_package_file))
+
+    assert builder_path == str(builder_dir / "lib" / "build-labextension.js")
+    assert marker_pkg == "@jupyter/builder"
+
+
+def test_ensure_builder_with_jupyterlab_builder(tmp_path):
+    ext_path = tmp_path / "ext"
+    core_path_dir = tmp_path / "core-meta"
+    core_package_file = core_path_dir / "core.package.json"
     builder_dir = ext_path / "node_modules" / "@jupyterlab" / "builder"
 
     builder_dir.mkdir(parents=True)
@@ -304,6 +323,7 @@ def test_ensure_builder_reads_custom_core_package_file(tmp_path):
     )
     (builder_dir / "package.json").write_text(json.dumps({"version": "5.0.0"}))
 
-    builder_path = _ensure_builder(str(ext_path), str(core_package_file))
+    builder_path, marker_pkg = _ensure_builder(str(ext_path), str(core_package_file))
 
     assert builder_path == str(builder_dir / "lib" / "build-labextension.js")
+    assert marker_pkg == "@jupyterlab/builder"

--- a/tests/test_tpl.py
+++ b/tests/test_tpl.py
@@ -103,6 +103,27 @@ def test_files_build_development(tmp_path):
         assert os.path.exists(filepath), f"File {filename} does not exist in {folder_path}!"
 
 
+def test_files_build_jupyterlab_builder(tmp_path):
+    extension_folder = tmp_path / "ext"
+    extension_folder.mkdir()
+    helper(str(extension_folder))
+
+    env = os.environ.copy()
+    env.update({"YARN_ENABLE_IMMUTABLE_INSTALLS": "false"})
+    run(["jlpm", "install"], cwd=extension_folder, check=True, env=env)
+    # Intentionally do NOT add @jupyter/builder; the template already declares
+    # @jupyterlab/builder, so this exercises the jupyterlab/builder path.
+    run(["jlpm", "run", "build:lib:prod"], cwd=extension_folder, check=True)
+
+    run(["jupyter-builder", "build", str(extension_folder)], cwd=extension_folder, check=True)
+
+    folder_path = extension_folder / "myextension/labextension"
+    expected_files = ["static/style.js", "package.json"]
+    for filename in expected_files:
+        filepath = os.path.join(folder_path, filename)
+        assert os.path.exists(filepath), f"File {filename} does not exist in {folder_path}!"
+
+
 # --------------------------------- WATCH TESTS ---------------------------------------
 
 
@@ -184,6 +205,50 @@ def test_watch_functionality(tmp_path):
     #     else:
     #         watch_process.send_signal(signal.SIGINT)
     #     watch_process.wait()
+
+
+def test_watch_functionality_jupyterlab_builder(tmp_path):
+    extension_folder = tmp_path / "ext"
+    extension_folder.mkdir()
+    helper(str(extension_folder))
+
+    env = os.environ.copy()
+    env.update({"YARN_ENABLE_IMMUTABLE_INSTALLS": "false"})
+    run(["jlpm", "install"], cwd=extension_folder, check=True, env=env)
+    # Intentionally do NOT add @jupyter/builder; exercises the jupyterlab/builder path.
+    run(["jlpm", "run", "build:lib:prod"], cwd=extension_folder, check=True)
+
+    index_ts_path = extension_folder / "src/index.ts"
+    static_dir = extension_folder / "myextension/labextension/static"
+    assert index_ts_path.exists(), f"File {index_ts_path} does not exist!"
+
+    initial_files = list_files_in_static(static_dir)
+
+    is_windows = platform.system() == "Windows"
+    kwargs = {"creationflags": subprocess.CREATE_NEW_PROCESS_GROUP} if is_windows else {}
+
+    watch_process = Popen(
+        ["jupyter-builder", "watch", str(extension_folder)], cwd=extension_folder, **kwargs
+    )
+
+    time.sleep(100)
+
+    try:
+        with index_ts_path.open("a") as f:
+            f.write("// Test comment to trigger watch\n")
+
+        time.sleep(100)
+
+        final_files = list_files_in_static(static_dir)
+        assert initial_files != final_files, (
+            "No changes detected in the static directory."
+            " Watch process may not have triggered correctly!"
+        )
+    finally:
+        watch_process.terminate()
+        time.sleep(5)
+        if watch_process.poll() is None:
+            watch_process.kill()
 
 
 def test_builder_version_mismatch(tmp_path):


### PR DESCRIPTION
### References #81 

### Description
Downstream extensions that download latest `jupyterlab` but do not yet depend upon `@jupyter/builder` and still only depend upon `@jupyterlab/builder` are having trouble building due to some design modification in `jupyter-builder`.
This PR adds a patch to support `@jupyterlab/builder` too.