### PR TITLE
Switch to stdlib HTTP + npm registry tarball fetching

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,13 +127,14 @@ watch_labextension(
 
 ### Environment variables
 
-jupyter-builder supports the following environment variable to override the npm registry URL —
+jupyter-builder supports the following environment variables to override network URLs —
 for example, to point at an internal mirror or a local proxy. A warning is emitted at startup
-whenever the variable is set.
+whenever a variable is set.
 
-| Variable        | Default                      | Purpose                                                           |
-| --------------- | ---------------------------- | ----------------------------------------------------------------- |
-| `JPBLD_NPM_URL` | `https://registry.npmjs.org` | npm registry used to resolve and download `@jupyterlab/core-meta` |
+| Variable               | Default                             | Purpose                                                           |
+| ---------------------- | ----------------------------------- | ----------------------------------------------------------------- |
+| `JPBLD_NPM_URL`        | `https://registry.npmjs.org`        | npm registry used to resolve and download `@jupyterlab/core-meta` |
+| `JPBLD_RAW_GITHUB_URL` | `https://raw.githubusercontent.com` | Raw GitHub content URL used as a fallback when npm is unavailable |
 
 **Example — redirect to a corporate npm mirror:**
 

--- a/README.md
+++ b/README.md
@@ -127,15 +127,13 @@ watch_labextension(
 
 ### Environment variables
 
-jupyter-builder uses several URLs when fetching JupyterLab core metadata. Each can be overridden
-via an environment variable — for example, to point at an internal mirror or a local proxy. A
-warning is emitted at startup whenever a variable is set.
+jupyter-builder supports the following environment variable to override the npm registry URL —
+for example, to point at an internal mirror or a local proxy. A warning is emitted at startup
+whenever the variable is set.
 
-| Variable               | Default                             | Purpose                                                           |
-| ---------------------- | ----------------------------------- | ----------------------------------------------------------------- |
-| `JPBLD_NPM_URL`        | `https://registry.npmjs.org`        | npm registry used to resolve and download `@jupyterlab/core-meta` |
-| `JPBLD_GITHUB_URL`     | `https://github.com`                | Base GitHub URL (reserved for future use)                         |
-| `JPBLD_RAW_GITHUB_URL` | `https://raw.githubusercontent.com` | Raw GitHub content URL used as a fallback when npm is unavailable |
+| Variable        | Default                      | Purpose                                                           |
+| --------------- | ---------------------------- | ----------------------------------------------------------------- |
+| `JPBLD_NPM_URL` | `https://registry.npmjs.org` | npm registry used to resolve and download `@jupyterlab/core-meta` |
 
 **Example — redirect to a corporate npm mirror:**
 

--- a/README.md
+++ b/README.md
@@ -125,6 +125,33 @@ watch_labextension(
 )
 ```
 
+### Environment variables
+
+jupyter-builder uses several URLs when fetching JupyterLab core metadata. Each can be overridden
+via an environment variable — for example, to point at an internal mirror or a local proxy. A
+warning is emitted at startup whenever a variable is set.
+
+| Variable               | Default                             | Purpose                                                           |
+| ---------------------- | ----------------------------------- | ----------------------------------------------------------------- |
+| `JPBLD_NPM_URL`        | `https://registry.npmjs.org`        | npm registry used to resolve and download `@jupyterlab/core-meta` |
+| `JPBLD_GITHUB_URL`     | `https://github.com`                | Base GitHub URL (reserved for future use)                         |
+| `JPBLD_RAW_GITHUB_URL` | `https://raw.githubusercontent.com` | Raw GitHub content URL used as a fallback when npm is unavailable |
+
+**Example — redirect to a corporate npm mirror:**
+
+```bash
+export JPBLD_NPM_URL=https://npm.internal.example.com
+jupyter-builder build /path/to/extension
+```
+
+**Core metadata resolution order**
+
+When no explicit `--core-version` is given, jupyter-builder looks for
+`@jupyterlab/core-meta` in the extension's `node_modules` first (no network
+required). If the package is not found there a warning is printed and the
+metadata is fetched from the npm registry, falling back to raw GitHub if npm
+is unreachable.
+
 ## Uninstall
 
 ```bash

--- a/jupyter_builder/constants.py
+++ b/jupyter_builder/constants.py
@@ -10,26 +10,14 @@ import warnings
 JPBLD_NPM_URL: str = os.getenv("JPBLD_NPM_URL", "https://registry.npmjs.org")
 
 #: Base GitHub URL for the jupyterlab/jupyterlab repository
-JPBLD_GITHUB_URL: str = os.getenv("JPBLD_GITHUB_URL", "https://github.com")
+JPBLD_GITHUB_URL: str = "https://github.com"
 
 #: Base raw GitHub content URL
-JPBLD_RAW_GITHUB_URL: str = os.getenv("JPBLD_RAW_GITHUB_URL", "https://raw.githubusercontent.com")
+JPBLD_RAW_GITHUB_URL: str = "https://raw.githubusercontent.com"
 
 if os.getenv("JPBLD_NPM_URL") is not None:
     warnings.warn(
         f"jupyter-builder: JPBLD_NPM_URL overridden to {JPBLD_NPM_URL!r}",
-        UserWarning,
-        stacklevel=2,
-    )
-if os.getenv("JPBLD_GITHUB_URL") is not None:
-    warnings.warn(
-        f"jupyter-builder: JPBLD_GITHUB_URL overridden to {JPBLD_GITHUB_URL!r}",
-        UserWarning,
-        stacklevel=2,
-    )
-if os.getenv("JPBLD_RAW_GITHUB_URL") is not None:
-    warnings.warn(
-        f"jupyter-builder: JPBLD_RAW_GITHUB_URL overridden to {JPBLD_RAW_GITHUB_URL!r}",
         UserWarning,
         stacklevel=2,
     )

--- a/jupyter_builder/constants.py
+++ b/jupyter_builder/constants.py
@@ -9,15 +9,19 @@ import warnings
 #: Base URL for the npm registry
 JPBLD_NPM_URL: str = os.getenv("JPBLD_NPM_URL", "https://registry.npmjs.org")
 
-#: Base GitHub URL for the jupyterlab/jupyterlab repository
-JPBLD_GITHUB_URL: str = "https://github.com"
-
 #: Base raw GitHub content URL
-JPBLD_RAW_GITHUB_URL: str = "https://raw.githubusercontent.com"
+JPBLD_RAW_GITHUB_URL: str = os.getenv("JPBLD_RAW_GITHUB_URL", "https://raw.githubusercontent.com")
 
 if os.getenv("JPBLD_NPM_URL") is not None:
     warnings.warn(
         f"jupyter-builder: JPBLD_NPM_URL overridden to {JPBLD_NPM_URL!r}",
+        UserWarning,
+        stacklevel=2,
+    )
+
+if os.getenv("JPBLD_RAW_GITHUB_URL") is not None:
+    warnings.warn(
+        f"jupyter-builder: JPBLD_RAW_GITHUB_URL overridden to {JPBLD_RAW_GITHUB_URL!r}",
         UserWarning,
         stacklevel=2,
     )

--- a/jupyter_builder/constants.py
+++ b/jupyter_builder/constants.py
@@ -1,0 +1,35 @@
+"""URL constants for jupyter-builder network fetches, overridable via environment variables."""
+
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+
+import os
+import warnings
+
+#: Base URL for the npm registry
+JPBLD_NPM_URL: str = os.getenv("JPBLD_NPM_URL", "https://registry.npmjs.org")
+
+#: Base GitHub URL for the jupyterlab/jupyterlab repository
+JPBLD_GITHUB_URL: str = os.getenv("JPBLD_GITHUB_URL", "https://github.com")
+
+#: Base raw GitHub content URL
+JPBLD_RAW_GITHUB_URL: str = os.getenv("JPBLD_RAW_GITHUB_URL", "https://raw.githubusercontent.com")
+
+if os.getenv("JPBLD_NPM_URL") is not None:
+    warnings.warn(
+        f"jupyter-builder: JPBLD_NPM_URL overridden to {JPBLD_NPM_URL!r}",
+        UserWarning,
+        stacklevel=2,
+    )
+if os.getenv("JPBLD_GITHUB_URL") is not None:
+    warnings.warn(
+        f"jupyter-builder: JPBLD_GITHUB_URL overridden to {JPBLD_GITHUB_URL!r}",
+        UserWarning,
+        stacklevel=2,
+    )
+if os.getenv("JPBLD_RAW_GITHUB_URL") is not None:
+    warnings.warn(
+        f"jupyter-builder: JPBLD_RAW_GITHUB_URL overridden to {JPBLD_RAW_GITHUB_URL!r}",
+        UserWarning,
+        stacklevel=2,
+    )

--- a/jupyter_builder/constants.py
+++ b/jupyter_builder/constants.py
@@ -3,9 +3,6 @@
 
 """URL constants for jupyter-builder network fetches, overridable via environment variables."""
 
-# Copyright (c) Jupyter Development Team.
-# Distributed under the terms of the Modified BSD License.
-
 import os
 import warnings
 

--- a/jupyter_builder/constants.py
+++ b/jupyter_builder/constants.py
@@ -1,6 +1,3 @@
-# Copyright (c) Jupyter Development Team.
-# Distributed under the terms of the Modified BSD License.
-
 """URL constants for jupyter-builder network fetches, overridable via environment variables."""
 
 # Copyright (c) Jupyter Development Team.

--- a/jupyter_builder/constants.py
+++ b/jupyter_builder/constants.py
@@ -1,3 +1,6 @@
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+
 """URL constants for jupyter-builder network fetches, overridable via environment variables."""
 
 # Copyright (c) Jupyter Development Team.

--- a/jupyter_builder/core_path.py
+++ b/jupyter_builder/core_path.py
@@ -5,13 +5,13 @@
 
 import io
 import json
+import logging
 import os
 import re
 import subprocess
 import tarfile
 import urllib.error
 import urllib.request
-import warnings
 from pathlib import Path
 
 from .constants import JPBLD_NPM_URL, JPBLD_RAW_GITHUB_URL
@@ -39,22 +39,22 @@ def _http_get(url: str, *, headers: dict[str, str] | None = None, timeout: int =
 def get_core_meta(
     version: str | None = None,
     ext_path: str | os.PathLike[str] | None = None,
+    logger: logging.Logger | None = None,
 ) -> str:
     """Return the path to the core package JSON, downloading it if needed."""
     requested_version = version
-
     if requested_version is None:
         if ext_path is not None:
             installed_core_meta = _get_installed_core_meta(Path(ext_path).resolve())
             if installed_core_meta is not None:
                 return installed_core_meta
-            warnings.warn(
-                "@jupyterlab/core-meta was not found in node_modules, so a network download "
-                "will be used as a fallback. To avoid this, "
-                "add @jupyter/builder as a devDependency instead of @jupyterlab/builder.",
-                UserWarning,
-                stacklevel=2,
-            )
+            if logger:
+                logger.warning(
+                    "\033[33m@jupyterlab/core-meta was not found in node_modules, "
+                    "so a network download will be used as a fallback. To avoid this, "
+                    "add @jupyter/builder as a devDependency instead of "
+                    "@jupyterlab/builder.\n \033[0m",
+                )
         requested_version = "main"
 
     cache_root = _home_dir() / ".cache" / "jupyterlab_builder" / "core"

--- a/jupyter_builder/core_path.py
+++ b/jupyter_builder/core_path.py
@@ -3,17 +3,29 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 
+import io
+import json
 import os
 import re
 import subprocess
+import tarfile
+import urllib.error
+import urllib.request
 from pathlib import Path
 
-import requests
+NPM_REGISTRY = "https://registry.npmjs.org"
 
 
 def _home_dir() -> Path:
     home = os.environ.get("HOME")
     return Path(home) if home else Path.home()
+
+
+def _http_get(url: str, *, headers: dict[str, str] | None = None, timeout: int = 10) -> bytes:
+    req = urllib.request.Request(url, headers=headers) if headers else url  # noqa: S310
+    with urllib.request.urlopen(req, timeout=timeout) as resp:  # noqa: S310
+        data = resp.read()
+        return data if isinstance(data, bytes) else data.encode()
 
 
 def get_core_meta(
@@ -43,7 +55,7 @@ def get_core_meta(
             return str(npm_cache_file)
         _download_npm_core_meta(npm_version, npm_cache_file)
         return str(npm_cache_file)
-    except requests.RequestException:
+    except urllib.error.URLError:
         pass  # Fallback to GitHub below
 
     github_cache_file = cache_root / requested_version / "core.package.json"
@@ -64,12 +76,11 @@ def _resolve_npm_version(version: str) -> str:
     - anything else is returned as-is (assumed to be a concrete version)
     """
     if version == "latest":
-        r = requests.get("https://registry.npmjs.org/@jupyterlab/core-meta/latest", timeout=10)
-        r.raise_for_status()
-        latest_version = r.json().get("version")
+        data = _http_get(f"{NPM_REGISTRY}/@jupyterlab/core-meta/latest")
+        latest_version = json.loads(data).get("version")
         if not isinstance(latest_version, str) or not latest_version:
             msg = "Failed to resolve latest @jupyterlab/core-meta version from npm"
-            raise requests.RequestException(msg)
+            raise urllib.error.URLError(msg)
         return latest_version
 
     if _is_wildcard_version(version):
@@ -81,25 +92,24 @@ def _resolve_npm_version(version: str) -> str:
 def _resolve_wildcard_npm_version(version: str) -> str:
     """Fetch the highest published npm version matching a wildcard range like '4.5.x'.
 
-    Raises requests.RequestException if no matching version is found.
+    Raises urllib.error.URLError if no matching version is found.
     """
-    r = requests.get(
-        "https://registry.npmjs.org/@jupyterlab/core-meta",
+    data = _http_get(
+        f"{NPM_REGISTRY}/@jupyterlab/core-meta",
         headers={"Accept": "application/vnd.npm.install-v1+json"},
-        timeout=10,
     )
-    r.raise_for_status()
-    all_versions: list[str] = list(r.json().get("versions", {}).keys())
+    all_versions: list[str] = list(json.loads(data).get("versions", {}).keys())
 
-    # Build a regex from the wildcard pattern, e.g. "4.5.x" → r"^4\.5\.\d+$"
+    # Build a regex from the wildcard pattern, e.g. "4.5.x" → r"^4\.5\.\d+(-.+)?$"
+    # The (-.+)? suffix matches pre-release identifiers like -alpha.3, -beta.1, -rc.2
     escaped = re.escape(version)
     wildcard_pattern = re.sub(r"x", r"\\d+", escaped, flags=re.IGNORECASE)
-    pattern = "^" + wildcard_pattern + "$"
+    pattern = "^" + wildcard_pattern + r"(-.+)?$"
 
     matching = [v for v in all_versions if re.match(pattern, v)]
     if not matching:
         msg = f"No published @jupyterlab/core-meta versions match range '{version}'"
-        raise requests.RequestException(msg)
+        raise urllib.error.URLError(msg)
 
     def semver_key(v: str) -> tuple[int, ...]:
         return tuple(int(part) for part in re.split(r"[.\-]", v) if part.isdigit())
@@ -120,10 +130,18 @@ def _get_cached_core_meta_file(cache_root: Path, version: str) -> Path | None:
 
 def _download_npm_core_meta(version: str, destination: Path) -> None:
     destination.parent.mkdir(parents=True, exist_ok=True)
-    url = f"https://unpkg.com/@jupyterlab/core-meta@{version}/core.package.json"
-    r = requests.get(url, timeout=10)
-    r.raise_for_status()
-    destination.write_bytes(r.content)
+    metadata = json.loads(_http_get(f"{NPM_REGISTRY}/@jupyterlab/core-meta/{version}"))
+    tarball_url = metadata["dist"]["tarball"]
+    tarball_data = _http_get(tarball_url, timeout=20)
+    with tarfile.open(fileobj=io.BytesIO(tarball_data), mode="r:gz") as tar:
+        for member in tar.getmembers():
+            if member.name.endswith("core.package.json"):
+                f = tar.extractfile(member)
+                if f:
+                    destination.write_bytes(f.read())
+                    return
+    msg = "core.package.json not found in package tarball"
+    raise FileNotFoundError(msg)
 
 
 def _download_github_core_meta(version: str, destination: Path) -> None:
@@ -133,9 +151,7 @@ def _download_github_core_meta(version: str, destination: Path) -> None:
         f"jupyterlab/jupyterlab/{version}/"
         "jupyterlab/staging/package.json"
     )
-    r = requests.get(url, timeout=10)
-    r.raise_for_status()
-    destination.write_bytes(r.content)
+    destination.write_bytes(_http_get(url))
 
 
 def _get_installed_core_meta(ext_path: Path) -> str | None:

--- a/jupyter_builder/core_path.py
+++ b/jupyter_builder/core_path.py
@@ -14,6 +14,7 @@ import urllib.request
 from pathlib import Path
 
 NPM_REGISTRY = "https://registry.npmjs.org"
+_MAX_CORE_META_BYTES = 5 * 1024 * 1024  # 5 MB — generous upper bound for core.package.json
 
 
 def _home_dir() -> Path:
@@ -22,10 +23,15 @@ def _home_dir() -> Path:
 
 
 def _http_get(url: str, *, headers: dict[str, str] | None = None, timeout: int = 10) -> bytes:
-    req = urllib.request.Request(url, headers=headers) if headers else url  # noqa: S310
+    if not url.startswith(("http:", "https:")):
+        msg = "URL must start with 'http:' or 'https:'"
+        raise ValueError(msg)
+    request_headers = {"User-Agent": "jupyter-builder"}
+    if headers:
+        request_headers.update(headers)
+    req = urllib.request.Request(url, headers=request_headers)  # noqa: S310
     with urllib.request.urlopen(req, timeout=timeout) as resp:  # noqa: S310
-        data = resp.read()
-        return data if isinstance(data, bytes) else data.encode()
+        return bytes(resp.read())
 
 
 def get_core_meta(
@@ -111,8 +117,11 @@ def _resolve_wildcard_npm_version(version: str) -> str:
         msg = f"No published @jupyterlab/core-meta versions match range '{version}'"
         raise urllib.error.URLError(msg)
 
-    def semver_key(v: str) -> tuple[int, ...]:
-        return tuple(int(part) for part in re.split(r"[.\-]", v) if part.isdigit())
+    def semver_key(v: str) -> tuple[tuple[int, ...], int]:
+        release, _, _ = v.partition("-")
+        numeric = tuple(int(p) for p in release.split(".") if p.isdigit())
+        # Stable releases sort higher than pre-releases.
+        return (numeric, 0 if "-" in v else 1)
 
     return max(matching, key=semver_key)
 
@@ -131,17 +140,27 @@ def _get_cached_core_meta_file(cache_root: Path, version: str) -> Path | None:
 def _download_npm_core_meta(version: str, destination: Path) -> None:
     destination.parent.mkdir(parents=True, exist_ok=True)
     metadata = json.loads(_http_get(f"{NPM_REGISTRY}/@jupyterlab/core-meta/{version}"))
-    tarball_url = metadata["dist"]["tarball"]
+    try:
+        tarball_url = metadata["dist"]["tarball"]
+    except (KeyError, TypeError) as exc:
+        msg = f"Unexpected registry metadata for {version}: {exc}"
+        raise urllib.error.URLError(msg) from exc
     tarball_data = _http_get(tarball_url, timeout=20)
     with tarfile.open(fileobj=io.BytesIO(tarball_data), mode="r:gz") as tar:
         for member in tar.getmembers():
-            if member.name.endswith("core.package.json"):
+            if member.name == "package/core.package.json":
+                if not member.isfile():
+                    msg = "core.package.json entry is not a regular file"
+                    raise urllib.error.URLError(msg)
+                if member.size > _MAX_CORE_META_BYTES:
+                    msg = f"core.package.json entry exceeds size limit ({member.size} bytes)"
+                    raise urllib.error.URLError(msg)
                 f = tar.extractfile(member)
                 if f:
-                    destination.write_bytes(f.read())
+                    destination.write_bytes(f.read(_MAX_CORE_META_BYTES))
                     return
-    msg = "core.package.json not found in package tarball"
-    raise FileNotFoundError(msg)
+    msg = f"core.package.json not found in tarball for {version}"
+    raise urllib.error.URLError(msg)
 
 
 def _download_github_core_meta(version: str, destination: Path) -> None:

--- a/jupyter_builder/core_path.py
+++ b/jupyter_builder/core_path.py
@@ -11,9 +11,11 @@ import subprocess
 import tarfile
 import urllib.error
 import urllib.request
+import warnings
 from pathlib import Path
 
-NPM_REGISTRY = "https://registry.npmjs.org"
+from .constants import JPBLD_NPM_URL, JPBLD_RAW_GITHUB_URL
+
 _MAX_CORE_META_BYTES = 5 * 1024 * 1024  # 5 MB — generous upper bound for core.package.json
 
 
@@ -46,6 +48,13 @@ def get_core_meta(
             installed_core_meta = _get_installed_core_meta(Path(ext_path).resolve())
             if installed_core_meta is not None:
                 return installed_core_meta
+            warnings.warn(
+                "@jupyterlab/core-meta was not found in node_modules, so a network download "
+                "will be used as a fallback. To avoid this, "
+                "add @jupyter/builder as a devDependency instead of @jupyterlab/builder.",
+                UserWarning,
+                stacklevel=2,
+            )
         requested_version = "main"
 
     cache_root = _home_dir() / ".cache" / "jupyterlab_builder" / "core"
@@ -82,7 +91,7 @@ def _resolve_npm_version(version: str) -> str:
     - anything else is returned as-is (assumed to be a concrete version)
     """
     if version == "latest":
-        data = _http_get(f"{NPM_REGISTRY}/@jupyterlab/core-meta/latest")
+        data = _http_get(f"{JPBLD_NPM_URL}/@jupyterlab/core-meta/latest")
         latest_version = json.loads(data).get("version")
         if not isinstance(latest_version, str) or not latest_version:
             msg = "Failed to resolve latest @jupyterlab/core-meta version from npm"
@@ -101,7 +110,7 @@ def _resolve_wildcard_npm_version(version: str) -> str:
     Raises urllib.error.URLError if no matching version is found.
     """
     data = _http_get(
-        f"{NPM_REGISTRY}/@jupyterlab/core-meta",
+        f"{JPBLD_NPM_URL}/@jupyterlab/core-meta",
         headers={"Accept": "application/vnd.npm.install-v1+json"},
     )
     all_versions: list[str] = list(json.loads(data).get("versions", {}).keys())
@@ -117,11 +126,12 @@ def _resolve_wildcard_npm_version(version: str) -> str:
         msg = f"No published @jupyterlab/core-meta versions match range '{version}'"
         raise urllib.error.URLError(msg)
 
-    def semver_key(v: str) -> tuple[tuple[int, ...], int]:
-        release, _, _ = v.partition("-")
+    def semver_key(v: str) -> tuple[tuple[int, ...], int, tuple[int, ...]]:
+        release, _, prerelease = v.partition("-")
         numeric = tuple(int(p) for p in release.split(".") if p.isdigit())
-        # Stable releases sort higher than pre-releases.
-        return (numeric, 0 if "-" in v else 1)
+        # Stable releases sort higher than pre-releases; within pre-releases,
+        pre_numeric = tuple(int(p) for p in prerelease.split(".") if p.isdigit())
+        return (numeric, 0 if prerelease else 1, pre_numeric)
 
     return max(matching, key=semver_key)
 
@@ -139,7 +149,7 @@ def _get_cached_core_meta_file(cache_root: Path, version: str) -> Path | None:
 
 def _download_npm_core_meta(version: str, destination: Path) -> None:
     destination.parent.mkdir(parents=True, exist_ok=True)
-    metadata = json.loads(_http_get(f"{NPM_REGISTRY}/@jupyterlab/core-meta/{version}"))
+    metadata = json.loads(_http_get(f"{JPBLD_NPM_URL}/@jupyterlab/core-meta/{version}"))
     try:
         tarball_url = metadata["dist"]["tarball"]
     except (KeyError, TypeError) as exc:
@@ -165,11 +175,7 @@ def _download_npm_core_meta(version: str, destination: Path) -> None:
 
 def _download_github_core_meta(version: str, destination: Path) -> None:
     destination.parent.mkdir(parents=True, exist_ok=True)
-    url = (
-        "https://raw.githubusercontent.com/"
-        f"jupyterlab/jupyterlab/{version}/"
-        "jupyterlab/staging/package.json"
-    )
+    url = f"{JPBLD_RAW_GITHUB_URL}/jupyterlab/jupyterlab/{version}/jupyterlab/staging/package.json"
     destination.write_bytes(_http_get(url))
 
 

--- a/jupyter_builder/federated_extensions.py
+++ b/jupyter_builder/federated_extensions.py
@@ -227,7 +227,11 @@ def build_labextension(  # noqa: PLR0913
         if core_path_package.exists():
             core_package_file = str(core_path_package)
 
-    core_package_file = core_package_file or get_core_meta(core_version, ext_path=ext_path)
+    core_package_file = core_package_file or get_core_meta(
+        core_version,
+        ext_path=ext_path,
+        logger=logger,
+    )
     core_package_file = str(Path(core_package_file).resolve())
 
     if logger:
@@ -262,7 +266,11 @@ def watch_labextension(  # noqa: PLR0913
 ) -> None:
     """Watch a labextension in a given path."""
     ext_path = str(Path(path).resolve())
-    core_package_file = core_package_file or get_core_meta(core_version, ext_path=ext_path)
+    core_package_file = core_package_file or get_core_meta(
+        core_version,
+        ext_path=ext_path,
+        logger=logger,
+    )
     core_package_file = str(Path(core_package_file).resolve())
 
     if logger:

--- a/package.json
+++ b/package.json
@@ -1,100 +1,100 @@
 {
-    "name": "@jupyter/builder",
-    "version": "1.0.0-beta.1",
-    "description": "Jupyter build tools.",
-    "keywords": [
-        "jupyter",
-        "jupyterlab"
-    ],
-    "homepage": "https://github.com/jupyterlab/jupyter-builder",
-    "bugs": {
-        "url": "https://github.com/jupyterlab/jupyter-builder/issues"
-    },
-    "license": "BSD-3-Clause",
-    "author": {
-        "name": "Jupyter Development Team",
-        "email": "jupyter@googlegroups.com"
-    },
-    "files": [
-        "lib/**/*.{d.ts,eot,gif,html,jpg,js,js.map,json,png,svg,woff2,ttf}",
-        "src/**/*.{ts,tsx}"
-    ],
-    "main": "lib/index.js",
-    "types": "lib/index.d.ts",
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/jupyterlab/jupyter-builder.git"
-    },
-    "scripts": {
-        "build": "jlpm build:lib",
-        "build:prod": "jlpm clean && jlpm build:lib:prod",
-        "build:lib": "tsc --sourceMap",
-        "build:lib:prod": "tsc",
-        "clean": "jlpm clean:lib",
-        "clean:lib": "rimraf lib tsconfig.tsbuildinfo",
-        "clean:lintcache": "rimraf .eslintcache",
-        "clean:all": "jlpm clean:lib && jlpm clean:lintcache",
-        "eslint": "jlpm eslint:check --fix",
-        "eslint:check": "eslint . --cache --ext .ts,.tsx",
-        "lint": "jlpm prettier && jlpm eslint",
-        "lint:check": "jlpm prettier:check && jlpm eslint:check",
-        "prettier": "jlpm prettier:base --write --list-different",
-        "prettier:base": "prettier \"**/*{.ts,.tsx,.js,.jsx,.css,.json,.md}\"",
-        "prettier:check": "jlpm prettier:base --check",
-        "watch": "tsc -w --sourceMap"
-    },
-    "dependencies": {
-        "@jupyterlab/core-meta": "4.6.0-alpha.4",
-        "@module-federation/runtime-tools": "^2.0.0",
-        "@rspack/core": "^2.0.2",
-        "ajv": "^8.12.0",
-        "commander": "^9.4.1",
-        "css-loader": "^6.7.1",
-        "duplicate-package-checker-webpack-plugin": "^3.0.0",
-        "fs-extra": "^10.1.0",
-        "glob": "~7.1.6",
-        "license-webpack-plugin": "^4.0.2",
-        "mini-svg-data-uri": "^1.4.4",
-        "path-browserify": "^1.0.0",
-        "process": "^0.11.10",
-        "source-map-loader": "~1.0.2",
-        "style-loader": "~3.3.1",
-        "supports-color": "^7.2.0",
-        "webpack-merge": "^5.8.0",
-        "worker-loader": "^3.0.2"
-    },
-    "devDependencies": {
-        "@eslint/js": "^10.0.1",
-        "@types/fs-extra": "^9.0.1",
-        "@types/glob": "^7.1.1",
-        "@types/node": "^20.14.8",
-        "@types/supports-color": "^5.3.0",
-        "@types/watchpack": "^2.4.4",
-        "eslint": "^9.26.0",
-        "eslint-config-prettier": "^10.0.0",
-        "eslint-plugin-prettier": "^5.0.0",
-        "npm-run-all": "^4.1.5",
-        "prettier": "^3.8.1",
-        "rimraf": "~5.0.5",
-        "source-map-loader": "^1.0.2",
-        "typescript": "~5.9.3",
-        "typescript-eslint": "^8.0.0"
-    },
-    "publishConfig": {
-        "access": "public"
-    },
-    "prettier": {
-        "singleQuote": true,
-        "trailingComma": "none",
-        "arrowParens": "avoid",
-        "endOfLine": "auto",
-        "overrides": [
-            {
-                "files": "package.json",
-                "options": {
-                    "tabWidth": 4
-                }
-            }
-        ]
-    }
+  "name": "@jupyter/builder",
+  "version": "1.0.0-beta.1",
+  "description": "Jupyter build tools.",
+  "keywords": [
+    "jupyter",
+    "jupyterlab"
+  ],
+  "homepage": "https://github.com/jupyterlab/jupyter-builder",
+  "bugs": {
+    "url": "https://github.com/jupyterlab/jupyter-builder/issues"
+  },
+  "license": "BSD-3-Clause",
+  "author": {
+    "name": "Jupyter Development Team",
+    "email": "jupyter@googlegroups.com"
+  },
+  "files": [
+    "lib/**/*.{d.ts,eot,gif,html,jpg,js,js.map,json,png,svg,woff2,ttf}",
+    "src/**/*.{ts,tsx}"
+  ],
+  "main": "lib/index.js",
+  "types": "lib/index.d.ts",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jupyterlab/jupyter-builder.git"
+  },
+  "scripts": {
+    "build": "jlpm build:lib",
+    "build:prod": "jlpm clean && jlpm build:lib:prod",
+    "build:lib": "tsc --sourceMap",
+    "build:lib:prod": "tsc",
+    "clean": "jlpm clean:lib",
+    "clean:lib": "rimraf lib tsconfig.tsbuildinfo",
+    "clean:lintcache": "rimraf .eslintcache",
+    "clean:all": "jlpm clean:lib && jlpm clean:lintcache",
+    "eslint": "jlpm eslint:check --fix",
+    "eslint:check": "eslint . --cache --ext .ts,.tsx",
+    "lint": "jlpm prettier && jlpm eslint",
+    "lint:check": "jlpm prettier:check && jlpm eslint:check",
+    "prettier": "jlpm prettier:base --write --list-different",
+    "prettier:base": "prettier \"**/*{.ts,.tsx,.js,.jsx,.css,.json,.md}\"",
+    "prettier:check": "jlpm prettier:base --check",
+    "watch": "tsc -w --sourceMap"
+  },
+  "dependencies": {
+    "@jupyterlab/core-meta": "4.6.0-alpha.4",
+    "@module-federation/runtime-tools": "^2.0.0",
+    "@rspack/core": "^2.0.2",
+    "ajv": "^8.12.0",
+    "commander": "^9.4.1",
+    "css-loader": "^6.7.1",
+    "duplicate-package-checker-webpack-plugin": "^3.0.0",
+    "fs-extra": "^10.1.0",
+    "glob": "~7.1.6",
+    "license-webpack-plugin": "^4.0.2",
+    "mini-svg-data-uri": "^1.4.4",
+    "path-browserify": "^1.0.0",
+    "process": "^0.11.10",
+    "source-map-loader": "~1.0.2",
+    "style-loader": "~3.3.1",
+    "supports-color": "^7.2.0",
+    "webpack-merge": "^5.8.0",
+    "worker-loader": "^3.0.2"
+  },
+  "devDependencies": {
+    "@eslint/js": "^10.0.1",
+    "@types/fs-extra": "^9.0.1",
+    "@types/glob": "^7.1.1",
+    "@types/node": "^20.14.8",
+    "@types/supports-color": "^5.3.0",
+    "@types/watchpack": "^2.4.4",
+    "eslint": "^9.26.0",
+    "eslint-config-prettier": "^10.0.0",
+    "eslint-plugin-prettier": "^5.0.0",
+    "npm-run-all": "^4.1.5",
+    "prettier": "^3.8.1",
+    "rimraf": "~5.0.5",
+    "source-map-loader": "^1.0.2",
+    "typescript": "~5.9.3",
+    "typescript-eslint": "^8.0.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "prettier": {
+    "singleQuote": true,
+    "trailingComma": "none",
+    "arrowParens": "avoid",
+    "endOfLine": "auto",
+    "overrides": [
+      {
+        "files": "package.json",
+        "options": {
+          "tabWidth": 2
+        }
+      }
+    ]
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,100 +1,100 @@
 {
-  "name": "@jupyter/builder",
-  "version": "1.0.0-beta.1",
-  "description": "Jupyter build tools.",
-  "keywords": [
-    "jupyter",
-    "jupyterlab"
-  ],
-  "homepage": "https://github.com/jupyterlab/jupyter-builder",
-  "bugs": {
-    "url": "https://github.com/jupyterlab/jupyter-builder/issues"
-  },
-  "license": "BSD-3-Clause",
-  "author": {
-    "name": "Jupyter Development Team",
-    "email": "jupyter@googlegroups.com"
-  },
-  "files": [
-    "lib/**/*.{d.ts,eot,gif,html,jpg,js,js.map,json,png,svg,woff2,ttf}",
-    "src/**/*.{ts,tsx}"
-  ],
-  "main": "lib/index.js",
-  "types": "lib/index.d.ts",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/jupyterlab/jupyter-builder.git"
-  },
-  "scripts": {
-    "build": "jlpm build:lib",
-    "build:prod": "jlpm clean && jlpm build:lib:prod",
-    "build:lib": "tsc --sourceMap",
-    "build:lib:prod": "tsc",
-    "clean": "jlpm clean:lib",
-    "clean:lib": "rimraf lib tsconfig.tsbuildinfo",
-    "clean:lintcache": "rimraf .eslintcache",
-    "clean:all": "jlpm clean:lib && jlpm clean:lintcache",
-    "eslint": "jlpm eslint:check --fix",
-    "eslint:check": "eslint . --cache --ext .ts,.tsx",
-    "lint": "jlpm prettier && jlpm eslint",
-    "lint:check": "jlpm prettier:check && jlpm eslint:check",
-    "prettier": "jlpm prettier:base --write --list-different",
-    "prettier:base": "prettier \"**/*{.ts,.tsx,.js,.jsx,.css,.json,.md}\"",
-    "prettier:check": "jlpm prettier:base --check",
-    "watch": "tsc -w --sourceMap"
-  },
-  "dependencies": {
-    "@jupyterlab/core-meta": "4.6.0-alpha.4",
-    "@module-federation/runtime-tools": "^2.0.0",
-    "@rspack/core": "^2.0.2",
-    "ajv": "^8.12.0",
-    "commander": "^9.4.1",
-    "css-loader": "^6.7.1",
-    "duplicate-package-checker-webpack-plugin": "^3.0.0",
-    "fs-extra": "^10.1.0",
-    "glob": "~7.1.6",
-    "license-webpack-plugin": "^4.0.2",
-    "mini-svg-data-uri": "^1.4.4",
-    "path-browserify": "^1.0.0",
-    "process": "^0.11.10",
-    "source-map-loader": "~1.0.2",
-    "style-loader": "~3.3.1",
-    "supports-color": "^7.2.0",
-    "webpack-merge": "^5.8.0",
-    "worker-loader": "^3.0.2"
-  },
-  "devDependencies": {
-    "@eslint/js": "^10.0.1",
-    "@types/fs-extra": "^9.0.1",
-    "@types/glob": "^7.1.1",
-    "@types/node": "^20.14.8",
-    "@types/supports-color": "^5.3.0",
-    "@types/watchpack": "^2.4.4",
-    "eslint": "^9.26.0",
-    "eslint-config-prettier": "^10.0.0",
-    "eslint-plugin-prettier": "^5.0.0",
-    "npm-run-all": "^4.1.5",
-    "prettier": "^3.8.1",
-    "rimraf": "~5.0.5",
-    "source-map-loader": "^1.0.2",
-    "typescript": "~5.9.3",
-    "typescript-eslint": "^8.0.0"
-  },
-  "publishConfig": {
-    "access": "public"
-  },
-  "prettier": {
-    "singleQuote": true,
-    "trailingComma": "none",
-    "arrowParens": "avoid",
-    "endOfLine": "auto",
-    "overrides": [
-      {
-        "files": "package.json",
-        "options": {
-          "tabWidth": 4
-        }
-      }
-    ]
-  }
+    "name": "@jupyter/builder",
+    "version": "1.0.0-beta.1",
+    "description": "Jupyter build tools.",
+    "keywords": [
+        "jupyter",
+        "jupyterlab"
+    ],
+    "homepage": "https://github.com/jupyterlab/jupyter-builder",
+    "bugs": {
+        "url": "https://github.com/jupyterlab/jupyter-builder/issues"
+    },
+    "license": "BSD-3-Clause",
+    "author": {
+        "name": "Jupyter Development Team",
+        "email": "jupyter@googlegroups.com"
+    },
+    "files": [
+        "lib/**/*.{d.ts,eot,gif,html,jpg,js,js.map,json,png,svg,woff2,ttf}",
+        "src/**/*.{ts,tsx}"
+    ],
+    "main": "lib/index.js",
+    "types": "lib/index.d.ts",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/jupyterlab/jupyter-builder.git"
+    },
+    "scripts": {
+        "build": "jlpm build:lib",
+        "build:prod": "jlpm clean && jlpm build:lib:prod",
+        "build:lib": "tsc --sourceMap",
+        "build:lib:prod": "tsc",
+        "clean": "jlpm clean:lib",
+        "clean:lib": "rimraf lib tsconfig.tsbuildinfo",
+        "clean:lintcache": "rimraf .eslintcache",
+        "clean:all": "jlpm clean:lib && jlpm clean:lintcache",
+        "eslint": "jlpm eslint:check --fix",
+        "eslint:check": "eslint . --cache --ext .ts,.tsx",
+        "lint": "jlpm prettier && jlpm eslint",
+        "lint:check": "jlpm prettier:check && jlpm eslint:check",
+        "prettier": "jlpm prettier:base --write --list-different",
+        "prettier:base": "prettier \"**/*{.ts,.tsx,.js,.jsx,.css,.json,.md}\"",
+        "prettier:check": "jlpm prettier:base --check",
+        "watch": "tsc -w --sourceMap"
+    },
+    "dependencies": {
+        "@jupyterlab/core-meta": "4.6.0-alpha.4",
+        "@module-federation/runtime-tools": "^2.0.0",
+        "@rspack/core": "^2.0.2",
+        "ajv": "^8.12.0",
+        "commander": "^9.4.1",
+        "css-loader": "^6.7.1",
+        "duplicate-package-checker-webpack-plugin": "^3.0.0",
+        "fs-extra": "^10.1.0",
+        "glob": "~7.1.6",
+        "license-webpack-plugin": "^4.0.2",
+        "mini-svg-data-uri": "^1.4.4",
+        "path-browserify": "^1.0.0",
+        "process": "^0.11.10",
+        "source-map-loader": "~1.0.2",
+        "style-loader": "~3.3.1",
+        "supports-color": "^7.2.0",
+        "webpack-merge": "^5.8.0",
+        "worker-loader": "^3.0.2"
+    },
+    "devDependencies": {
+        "@eslint/js": "^10.0.1",
+        "@types/fs-extra": "^9.0.1",
+        "@types/glob": "^7.1.1",
+        "@types/node": "^20.14.8",
+        "@types/supports-color": "^5.3.0",
+        "@types/watchpack": "^2.4.4",
+        "eslint": "^9.26.0",
+        "eslint-config-prettier": "^10.0.0",
+        "eslint-plugin-prettier": "^5.0.0",
+        "npm-run-all": "^4.1.5",
+        "prettier": "^3.8.1",
+        "rimraf": "~5.0.5",
+        "source-map-loader": "^1.0.2",
+        "typescript": "~5.9.3",
+        "typescript-eslint": "^8.0.0"
+    },
+    "publishConfig": {
+        "access": "public"
+    },
+    "prettier": {
+        "singleQuote": true,
+        "trailingComma": "none",
+        "arrowParens": "avoid",
+        "endOfLine": "auto",
+        "overrides": [
+            {
+                "files": "package.json",
+                "options": {
+                    "tabWidth": 4
+                }
+            }
+        ]
+    }
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",
 ]
-dependencies = ["traitlets", "requests", "jupyter-core", "tomli; python_version < '3.11'"]
+dependencies = ["traitlets", "jupyter-core", "tomli; python_version < '3.11'"]
 dynamic = ["version"]
 
 [project.urls]

--- a/tests/test_core_path.py
+++ b/tests/test_core_path.py
@@ -1,14 +1,25 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 
+import io
 import json
+import tarfile
+import urllib.error
 from pathlib import Path
 
 import pytest
-import requests
 
 from jupyter_builder import core_path
 from jupyter_builder.federated_extensions import _ensure_builder
+
+
+def _make_core_package_tarball(content: bytes) -> bytes:
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as tar:
+        info = tarfile.TarInfo(name="package/core.package.json")
+        info.size = len(content)
+        tar.addfile(info, io.BytesIO(content))
+    return buf.getvalue()
 
 
 def test_get_core_meta_prefers_installed_core_meta(tmp_path):
@@ -69,32 +80,32 @@ def test_get_core_meta_fetches_npm_core_meta_before_github(tmp_path, monkeypatch
     def fake_check_call(_args, cwd):
         (Path(cwd) / "node_modules").mkdir(parents=True)
 
-    class FakeResponse:
-        def __init__(self, content=b"", json_data=None):
-            self.content = content
-            self._json_data = json_data
-
-        def raise_for_status(self):
-            return None
-
-        def json(self):
-            return self._json_data
+    tarball_content = b'{"devDependencies": {}}'
+    tarball_bytes = _make_core_package_tarball(tarball_content)
+    tarball_url = f"{core_path.NPM_REGISTRY}/@jupyterlab/core-meta/-/core-meta-4.6.0-alpha.4.tgz"
+    registry_meta = json.dumps({"dist": {"tarball": tarball_url}}).encode()
 
     calls = []
 
-    def fake_get(url, **_kwargs):
+    def fake_urlopen(req_or_url, **_kwargs):
+        url = getattr(req_or_url, "full_url", req_or_url)
         calls.append(url)
-        if url == "https://unpkg.com/@jupyterlab/core-meta@4.6.0-alpha.4/core.package.json":
-            return FakeResponse(content=b'{"devDependencies": {}}')
+        if url == f"{core_path.NPM_REGISTRY}/@jupyterlab/core-meta/4.6.0-alpha.4":
+            return io.BytesIO(registry_meta)
+        if url == tarball_url:
+            return io.BytesIO(tarball_bytes)
         msg = f"Unexpected URL {url}"
         raise AssertionError(msg)
 
     monkeypatch.setattr(core_path.subprocess, "check_call", fake_check_call)
-    monkeypatch.setattr(core_path.requests, "get", fake_get)
+    monkeypatch.setattr(core_path.urllib.request, "urlopen", fake_urlopen)
 
     location = core_path.get_core_meta(version="4.6.0-alpha.4", ext_path=ext_path)
 
-    assert calls == ["https://unpkg.com/@jupyterlab/core-meta@4.6.0-alpha.4/core.package.json"]
+    assert calls == [
+        f"{core_path.NPM_REGISTRY}/@jupyterlab/core-meta/4.6.0-alpha.4",
+        tarball_url,
+    ]
     assert location == str(
         tmp_path / ".cache" / "jupyterlab_builder" / "core" / "4.6.0-alpha.4" / "core.package.json",
     )
@@ -115,42 +126,31 @@ def test_get_core_meta_falls_back_to_github_when_npm_fails(tmp_path, monkeypatch
     ext_path.mkdir()
     monkeypatch.setenv("HOME", str(tmp_path))
 
-    class FakeResponse:
-        def __init__(self, content=b"", json_data=None, should_fail=False):
-            self.content = content
-            self._json_data = json_data
-            self._should_fail = should_fail
-
-        def raise_for_status(self):
-            if self._should_fail:
-                msg = "failed"
-                raise requests.HTTPError(msg)
-
-        def json(self):
-            return self._json_data
-
+    github_url = (
+        "https://raw.githubusercontent.com/"
+        "jupyterlab/jupyterlab/4.6.0-alpha.4/"
+        "jupyterlab/staging/package.json"
+    )
     calls = []
 
-    def fake_get(url, **_kwargs):
+    def fake_urlopen(req_or_url, **_kwargs):
+        url = getattr(req_or_url, "full_url", req_or_url)
         calls.append(url)
-        if url == "https://unpkg.com/@jupyterlab/core-meta@4.6.0-alpha.4/core.package.json":
-            return FakeResponse(should_fail=True)
-        if url == (
-            "https://raw.githubusercontent.com/"
-            "jupyterlab/jupyterlab/4.6.0-alpha.4/"
-            "jupyterlab/staging/package.json"
-        ):
-            return FakeResponse(content=b'{"dependencies": {}}')
+        if url == f"{core_path.NPM_REGISTRY}/@jupyterlab/core-meta/4.6.0-alpha.4":
+            msg = "Not Found"
+            raise urllib.error.URLError(msg)
+        if url == github_url:
+            return io.BytesIO(b'{"dependencies": {}}')
         msg = f"Unexpected URL {url}"
         raise AssertionError(msg)
 
-    monkeypatch.setattr(core_path.requests, "get", fake_get)
+    monkeypatch.setattr(core_path.urllib.request, "urlopen", fake_urlopen)
 
     location = core_path.get_core_meta(version="4.6.0-alpha.4", ext_path=ext_path)
 
     assert calls == [
-        "https://unpkg.com/@jupyterlab/core-meta@4.6.0-alpha.4/core.package.json",
-        "https://raw.githubusercontent.com/jupyterlab/jupyterlab/4.6.0-alpha.4/jupyterlab/staging/package.json",
+        f"{core_path.NPM_REGISTRY}/@jupyterlab/core-meta/4.6.0-alpha.4",
+        github_url,
     ]
     assert location == str(
         tmp_path / ".cache" / "jupyterlab_builder" / "core" / "4.6.0-alpha.4" / "core.package.json",
@@ -165,38 +165,35 @@ def test_get_core_meta_wildcard_version_resolves_from_npm_and_downloads_core_met
     ext_path.mkdir()
     monkeypatch.setenv("HOME", str(tmp_path))
 
-    class FakeResponse:
-        def __init__(self, content=b"", json_data=None):
-            self.content = content
-            self._json_data = json_data
-
-        def raise_for_status(self):
-            return None
-
-        def json(self):
-            return self._json_data
+    tarball_content = b'{"devDependencies": {}}'
+    tarball_bytes = _make_core_package_tarball(tarball_content)
+    tarball_url = f"{core_path.NPM_REGISTRY}/@jupyterlab/core-meta/-/core-meta-4.5.3.tgz"
+    registry_meta = json.dumps({"dist": {"tarball": tarball_url}}).encode()
 
     calls = []
 
-    def fake_get(url, **_kwargs):
+    def fake_urlopen(req_or_url, **_kwargs):
+        url = getattr(req_or_url, "full_url", req_or_url)
         calls.append(url)
-        if url == "https://registry.npmjs.org/@jupyterlab/core-meta":
-            return FakeResponse(
-                content=b"",
-                json_data={"versions": {"4.5.0": {}, "4.5.3": {}, "4.6.0": {}}},
+        if url == f"{core_path.NPM_REGISTRY}/@jupyterlab/core-meta":
+            return io.BytesIO(
+                json.dumps({"versions": {"4.5.0": {}, "4.5.3": {}, "4.6.0": {}}}).encode(),
             )
-        if url == "https://unpkg.com/@jupyterlab/core-meta@4.5.3/core.package.json":
-            return FakeResponse(content=b'{"devDependencies": {}}')
+        if url == f"{core_path.NPM_REGISTRY}/@jupyterlab/core-meta/4.5.3":
+            return io.BytesIO(registry_meta)
+        if url == tarball_url:
+            return io.BytesIO(tarball_bytes)
         msg = f"Unexpected URL {url}"
         raise AssertionError(msg)
 
-    monkeypatch.setattr(core_path.requests, "get", fake_get)
+    monkeypatch.setattr(core_path.urllib.request, "urlopen", fake_urlopen)
 
     location = core_path.get_core_meta(version="4.5.x", ext_path=ext_path)
 
     assert calls == [
-        "https://registry.npmjs.org/@jupyterlab/core-meta",
-        "https://unpkg.com/@jupyterlab/core-meta@4.5.3/core.package.json",
+        f"{core_path.NPM_REGISTRY}/@jupyterlab/core-meta",
+        f"{core_path.NPM_REGISTRY}/@jupyterlab/core-meta/4.5.3",
+        tarball_url,
     ]
     assert location == str(
         tmp_path / ".cache" / "jupyterlab_builder" / "core" / "4.5.3" / "core.package.json",
@@ -204,47 +201,62 @@ def test_get_core_meta_wildcard_version_resolves_from_npm_and_downloads_core_met
 
 
 def test_resolve_wildcard_npm_version_returns_highest_match(monkeypatch):
-    class FakeResponse:
-        def __init__(self, json_data):
-            self._json_data = json_data
-
-        def raise_for_status(self):
-            return None
-
-        def json(self):
-            return self._json_data
-
-    def fake_get(url, **_kwargs):
-        assert url == "https://registry.npmjs.org/@jupyterlab/core-meta"
-        return FakeResponse(
-            {
-                "versions": {
-                    "4.4.9": {},
-                    "4.5.1": {},
-                    "4.5.12": {},
-                    "4.6.0-alpha.4": {},
+    def fake_urlopen(req_or_url, **_kwargs):
+        url = getattr(req_or_url, "full_url", req_or_url)
+        assert url == f"{core_path.NPM_REGISTRY}/@jupyterlab/core-meta"
+        return io.BytesIO(
+            json.dumps(
+                {
+                    "versions": {
+                        "4.4.9": {},
+                        "4.5.1": {},
+                        "4.5.12": {},
+                        "4.6.0-alpha.4": {},
+                    },
                 },
-            },
+            ).encode(),
         )
 
-    monkeypatch.setattr(core_path.requests, "get", fake_get)
+    monkeypatch.setattr(core_path.urllib.request, "urlopen", fake_urlopen)
 
     resolved = core_path._resolve_wildcard_npm_version("4.5.x")
 
     assert resolved == "4.5.12"
 
 
+def test_resolve_wildcard_npm_version_matches_prerelease_versions(monkeypatch):
+    def fake_urlopen(req_or_url, **_kwargs):
+        url = getattr(req_or_url, "full_url", req_or_url)
+        assert url == f"{core_path.NPM_REGISTRY}/@jupyterlab/core-meta"
+        return io.BytesIO(
+            json.dumps(
+                {
+                    "versions": {
+                        "4.6.0-alpha.3": {},
+                        "4.6.0-alpha.4": {},
+                        "4.6.0-alpha.5": {},
+                    },
+                },
+            ).encode(),
+        )
+
+    monkeypatch.setattr(core_path.urllib.request, "urlopen", fake_urlopen)
+
+    resolved = core_path._resolve_wildcard_npm_version("4.6.x")
+
+    assert resolved == "4.6.0-alpha.5"
+
+
 def test_resolve_wildcard_npm_version_raises_when_no_matches(monkeypatch):
-    class FakeResponse:
-        def raise_for_status(self):
-            return None
+    monkeypatch.setattr(
+        core_path.urllib.request,
+        "urlopen",
+        lambda *_args, **_kwargs: io.BytesIO(
+            json.dumps({"versions": {"4.6.0": {}, "5.0.0": {}}}).encode(),
+        ),
+    )
 
-        def json(self):
-            return {"versions": {"4.6.0": {}, "5.0.0": {}}}
-
-    monkeypatch.setattr(core_path.requests, "get", lambda *_args, **_kwargs: FakeResponse())
-
-    with pytest.raises(requests.RequestException, match="No published @jupyterlab/core-meta"):
+    with pytest.raises(urllib.error.URLError, match="No published @jupyterlab/core-meta"):
         core_path._resolve_wildcard_npm_version("4.5.x")
 
 
@@ -253,35 +265,33 @@ def test_get_core_meta_latest_uses_npm_latest_and_caches_by_resolved_version(tmp
     ext_path.mkdir()
     monkeypatch.setenv("HOME", str(tmp_path))
 
-    class FakeResponse:
-        def __init__(self, content=b"", json_data=None):
-            self.content = content
-            self._json_data = json_data
-
-        def raise_for_status(self):
-            return None
-
-        def json(self):
-            return self._json_data
+    tarball_content = b'{"devDependencies": {}}'
+    tarball_bytes = _make_core_package_tarball(tarball_content)
+    tarball_url = f"{core_path.NPM_REGISTRY}/@jupyterlab/core-meta/-/core-meta-4.6.0-alpha.4.tgz"
+    registry_meta = json.dumps({"dist": {"tarball": tarball_url}}).encode()
 
     calls = []
 
-    def fake_get(url, **_kwargs):
+    def fake_urlopen(req_or_url, **_kwargs):
+        url = getattr(req_or_url, "full_url", req_or_url)
         calls.append(url)
-        if url == "https://registry.npmjs.org/@jupyterlab/core-meta/latest":
-            return FakeResponse(json_data={"version": "4.6.0-alpha.4"})
-        if url == "https://unpkg.com/@jupyterlab/core-meta@4.6.0-alpha.4/core.package.json":
-            return FakeResponse(content=b'{"devDependencies": {}}')
+        if url == f"{core_path.NPM_REGISTRY}/@jupyterlab/core-meta/latest":
+            return io.BytesIO(json.dumps({"version": "4.6.0-alpha.4"}).encode())
+        if url == f"{core_path.NPM_REGISTRY}/@jupyterlab/core-meta/4.6.0-alpha.4":
+            return io.BytesIO(registry_meta)
+        if url == tarball_url:
+            return io.BytesIO(tarball_bytes)
         msg = f"Unexpected URL {url}"
         raise AssertionError(msg)
 
-    monkeypatch.setattr(core_path.requests, "get", fake_get)
+    monkeypatch.setattr(core_path.urllib.request, "urlopen", fake_urlopen)
 
     location = core_path.get_core_meta(version="latest", ext_path=ext_path)
 
     assert calls == [
-        "https://registry.npmjs.org/@jupyterlab/core-meta/latest",
-        "https://unpkg.com/@jupyterlab/core-meta@4.6.0-alpha.4/core.package.json",
+        f"{core_path.NPM_REGISTRY}/@jupyterlab/core-meta/latest",
+        f"{core_path.NPM_REGISTRY}/@jupyterlab/core-meta/4.6.0-alpha.4",
+        tarball_url,
     ]
     assert location == str(
         tmp_path / ".cache" / "jupyterlab_builder" / "core" / "4.6.0-alpha.4" / "core.package.json",

--- a/tests/test_core_path.py
+++ b/tests/test_core_path.py
@@ -82,7 +82,7 @@ def test_get_core_meta_fetches_npm_core_meta_before_github(tmp_path, monkeypatch
 
     tarball_content = b'{"devDependencies": {}}'
     tarball_bytes = _make_core_package_tarball(tarball_content)
-    tarball_url = f"{core_path.NPM_REGISTRY}/@jupyterlab/core-meta/-/core-meta-4.6.0-alpha.4.tgz"
+    tarball_url = f"{core_path.JPBLD_NPM_URL}/@jupyterlab/core-meta/-/core-meta-4.6.0-alpha.4.tgz"
     registry_meta = json.dumps({"dist": {"tarball": tarball_url}}).encode()
 
     calls = []
@@ -90,7 +90,7 @@ def test_get_core_meta_fetches_npm_core_meta_before_github(tmp_path, monkeypatch
     def fake_urlopen(req_or_url, **_kwargs):
         url = getattr(req_or_url, "full_url", req_or_url)
         calls.append(url)
-        if url == f"{core_path.NPM_REGISTRY}/@jupyterlab/core-meta/4.6.0-alpha.4":
+        if url == f"{core_path.JPBLD_NPM_URL}/@jupyterlab/core-meta/4.6.0-alpha.4":
             return io.BytesIO(registry_meta)
         if url == tarball_url:
             return io.BytesIO(tarball_bytes)
@@ -103,7 +103,7 @@ def test_get_core_meta_fetches_npm_core_meta_before_github(tmp_path, monkeypatch
     location = core_path.get_core_meta(version="4.6.0-alpha.4", ext_path=ext_path)
 
     assert calls == [
-        f"{core_path.NPM_REGISTRY}/@jupyterlab/core-meta/4.6.0-alpha.4",
+        f"{core_path.JPBLD_NPM_URL}/@jupyterlab/core-meta/4.6.0-alpha.4",
         tarball_url,
     ]
     assert location == str(
@@ -136,7 +136,7 @@ def test_get_core_meta_falls_back_to_github_when_npm_fails(tmp_path, monkeypatch
     def fake_urlopen(req_or_url, **_kwargs):
         url = getattr(req_or_url, "full_url", req_or_url)
         calls.append(url)
-        if url == f"{core_path.NPM_REGISTRY}/@jupyterlab/core-meta/4.6.0-alpha.4":
+        if url == f"{core_path.JPBLD_NPM_URL}/@jupyterlab/core-meta/4.6.0-alpha.4":
             msg = "Not Found"
             raise urllib.error.URLError(msg)
         if url == github_url:
@@ -149,7 +149,7 @@ def test_get_core_meta_falls_back_to_github_when_npm_fails(tmp_path, monkeypatch
     location = core_path.get_core_meta(version="4.6.0-alpha.4", ext_path=ext_path)
 
     assert calls == [
-        f"{core_path.NPM_REGISTRY}/@jupyterlab/core-meta/4.6.0-alpha.4",
+        f"{core_path.JPBLD_NPM_URL}/@jupyterlab/core-meta/4.6.0-alpha.4",
         github_url,
     ]
     assert location == str(
@@ -167,7 +167,7 @@ def test_get_core_meta_wildcard_version_resolves_from_npm_and_downloads_core_met
 
     tarball_content = b'{"devDependencies": {}}'
     tarball_bytes = _make_core_package_tarball(tarball_content)
-    tarball_url = f"{core_path.NPM_REGISTRY}/@jupyterlab/core-meta/-/core-meta-4.5.3.tgz"
+    tarball_url = f"{core_path.JPBLD_NPM_URL}/@jupyterlab/core-meta/-/core-meta-4.5.3.tgz"
     registry_meta = json.dumps({"dist": {"tarball": tarball_url}}).encode()
 
     calls = []
@@ -175,11 +175,11 @@ def test_get_core_meta_wildcard_version_resolves_from_npm_and_downloads_core_met
     def fake_urlopen(req_or_url, **_kwargs):
         url = getattr(req_or_url, "full_url", req_or_url)
         calls.append(url)
-        if url == f"{core_path.NPM_REGISTRY}/@jupyterlab/core-meta":
+        if url == f"{core_path.JPBLD_NPM_URL}/@jupyterlab/core-meta":
             return io.BytesIO(
                 json.dumps({"versions": {"4.5.0": {}, "4.5.3": {}, "4.6.0": {}}}).encode(),
             )
-        if url == f"{core_path.NPM_REGISTRY}/@jupyterlab/core-meta/4.5.3":
+        if url == f"{core_path.JPBLD_NPM_URL}/@jupyterlab/core-meta/4.5.3":
             return io.BytesIO(registry_meta)
         if url == tarball_url:
             return io.BytesIO(tarball_bytes)
@@ -191,8 +191,8 @@ def test_get_core_meta_wildcard_version_resolves_from_npm_and_downloads_core_met
     location = core_path.get_core_meta(version="4.5.x", ext_path=ext_path)
 
     assert calls == [
-        f"{core_path.NPM_REGISTRY}/@jupyterlab/core-meta",
-        f"{core_path.NPM_REGISTRY}/@jupyterlab/core-meta/4.5.3",
+        f"{core_path.JPBLD_NPM_URL}/@jupyterlab/core-meta",
+        f"{core_path.JPBLD_NPM_URL}/@jupyterlab/core-meta/4.5.3",
         tarball_url,
     ]
     assert location == str(
@@ -203,7 +203,7 @@ def test_get_core_meta_wildcard_version_resolves_from_npm_and_downloads_core_met
 def test_resolve_wildcard_npm_version_returns_highest_match(monkeypatch):
     def fake_urlopen(req_or_url, **_kwargs):
         url = getattr(req_or_url, "full_url", req_or_url)
-        assert url == f"{core_path.NPM_REGISTRY}/@jupyterlab/core-meta"
+        assert url == f"{core_path.JPBLD_NPM_URL}/@jupyterlab/core-meta"
         return io.BytesIO(
             json.dumps(
                 {
@@ -227,7 +227,7 @@ def test_resolve_wildcard_npm_version_returns_highest_match(monkeypatch):
 def test_resolve_wildcard_npm_version_matches_prerelease_versions(monkeypatch):
     def fake_urlopen(req_or_url, **_kwargs):
         url = getattr(req_or_url, "full_url", req_or_url)
-        assert url == f"{core_path.NPM_REGISTRY}/@jupyterlab/core-meta"
+        assert url == f"{core_path.JPBLD_NPM_URL}/@jupyterlab/core-meta"
         return io.BytesIO(
             json.dumps(
                 {
@@ -267,7 +267,7 @@ def test_get_core_meta_latest_uses_npm_latest_and_caches_by_resolved_version(tmp
 
     tarball_content = b'{"devDependencies": {}}'
     tarball_bytes = _make_core_package_tarball(tarball_content)
-    tarball_url = f"{core_path.NPM_REGISTRY}/@jupyterlab/core-meta/-/core-meta-4.6.0-alpha.4.tgz"
+    tarball_url = f"{core_path.JPBLD_NPM_URL}/@jupyterlab/core-meta/-/core-meta-4.6.0-alpha.4.tgz"
     registry_meta = json.dumps({"dist": {"tarball": tarball_url}}).encode()
 
     calls = []
@@ -275,9 +275,9 @@ def test_get_core_meta_latest_uses_npm_latest_and_caches_by_resolved_version(tmp
     def fake_urlopen(req_or_url, **_kwargs):
         url = getattr(req_or_url, "full_url", req_or_url)
         calls.append(url)
-        if url == f"{core_path.NPM_REGISTRY}/@jupyterlab/core-meta/latest":
+        if url == f"{core_path.JPBLD_NPM_URL}/@jupyterlab/core-meta/latest":
             return io.BytesIO(json.dumps({"version": "4.6.0-alpha.4"}).encode())
-        if url == f"{core_path.NPM_REGISTRY}/@jupyterlab/core-meta/4.6.0-alpha.4":
+        if url == f"{core_path.JPBLD_NPM_URL}/@jupyterlab/core-meta/4.6.0-alpha.4":
             return io.BytesIO(registry_meta)
         if url == tarball_url:
             return io.BytesIO(tarball_bytes)
@@ -289,8 +289,8 @@ def test_get_core_meta_latest_uses_npm_latest_and_caches_by_resolved_version(tmp
     location = core_path.get_core_meta(version="latest", ext_path=ext_path)
 
     assert calls == [
-        f"{core_path.NPM_REGISTRY}/@jupyterlab/core-meta/latest",
-        f"{core_path.NPM_REGISTRY}/@jupyterlab/core-meta/4.6.0-alpha.4",
+        f"{core_path.JPBLD_NPM_URL}/@jupyterlab/core-meta/latest",
+        f"{core_path.JPBLD_NPM_URL}/@jupyterlab/core-meta/4.6.0-alpha.4",
         tarball_url,
     ]
     assert location == str(

--- a/tests/test_tpl.py
+++ b/tests/test_tpl.py
@@ -108,6 +108,14 @@ def test_files_build_jupyterlab_builder(tmp_path):
     extension_folder.mkdir()
     helper(str(extension_folder))
 
+    pin_webpack = (
+        "const fs=require('fs');"
+        " const p=require('./package.json');"
+        " p.resolutions = p.resolutions || {};"
+        " p.resolutions.webpack='5.106.0';"
+        " fs.writeFileSync('package.json', JSON.stringify(p,null,2));"
+    )
+    run(["node", "-e", pin_webpack], cwd=extension_folder, check=True)
     env = os.environ.copy()
     env.update({"YARN_ENABLE_IMMUTABLE_INSTALLS": "false"})
     run(["jlpm", "install"], cwd=extension_folder, check=True, env=env)
@@ -206,6 +214,14 @@ def test_watch_functionality_jupyterlab_builder(tmp_path):
     extension_folder.mkdir()
     helper(str(extension_folder))
 
+    pin_webpack = (
+        "const fs=require('fs');"
+        " const p=require('./package.json');"
+        " p.resolutions = p.resolutions || {};"
+        " p.resolutions.webpack='5.106.0';"
+        " fs.writeFileSync('package.json', JSON.stringify(p,null,2));"
+    )
+    run(["node", "-e", pin_webpack], cwd=extension_folder, check=True)
     env = os.environ.copy()
     env.update({"YARN_ENABLE_IMMUTABLE_INSTALLS": "false"})
     run(["jlpm", "install"], cwd=extension_folder, check=True, env=env)

--- a/tests/test_tpl.py
+++ b/tests/test_tpl.py
@@ -273,7 +273,7 @@ def test_builder_version_mismatch(tmp_path):
     # This exercises the backwards-compatible version-check path.
     with pytest.raises(subprocess.CalledProcessError) as excinfo:
         run(
-            ["jupyter-builder", "build", str(extension_folder)],
+            ["jupyter-builder", "build", str(extension_folder), "--core-version", "4.5.x"],
             cwd=extension_folder,
             check=True,
             capture_output=True,


### PR DESCRIPTION
## Fixes #82 

### Description

- Drop `requests` dependency and replace it with Python stdlib `urllib.request`
- Introduce `NPM_REGISTRY` constant for the registry base URL (we could make it configurable)
- Rewrite `_download_npm_core_meta` to fetch metadata via the official npm registry tarball flow: `registry.npmjs.org/<pkg>/<version>` → use `dist.tarball` → extract `core/package.json` instead of using unpkg