### PR TITLE
Bump `@jupyterlab/core-meta`

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
       {
         "files": "package.json",
         "options": {
-          "tabWidth": 4
+          "tabWidth": 2
         }
       }
     ]

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "watch": "tsc -w --sourceMap"
   },
   "dependencies": {
-    "@jupyterlab/core-meta": "4.6.0-alpha.4",
+    "@jupyterlab/core-meta": "4.6.0-beta.0",
     "@module-federation/runtime-tools": "^2.0.0",
     "@rspack/core": "^2.0.2",
     "ajv": "^8.12.0",

--- a/tests/test_tpl.py
+++ b/tests/test_tpl.py
@@ -270,9 +270,9 @@ def test_builder_version_mismatch(tmp_path):
 
     package_json_path = extension_folder / "package.json"
 
-    # Modify the @jupyterlab/builder version to an incompatible range
+    # Modify the @jupyter/builder version to an incompatible range
     package_data = json.loads(package_json_path.read_text())
-    package_data["devDependencies"]["@jupyterlab/builder"] = "3.0.0"
+    package_data["devDependencies"]["@jupyter/builder"] = "0.0.9"
     package_json_path.write_text(json.dumps(package_data, indent=2))
 
     env = os.environ.copy()
@@ -299,7 +299,7 @@ def test_builder_version_mismatch(tmp_path):
     assert re.search(
         (
             r"ValueError: Extensions require a devDependency on @jupyterlab/builder@\^.+?, "
-            r"you have a dependency on 3\.0\.0"
+            r"you have a dependency on 0\.0\.9"
         ),
         excinfo.value.stderr,
     ), "Expected version mismatch error message not found in output!"

--- a/tests/test_tpl.py
+++ b/tests/test_tpl.py
@@ -270,9 +270,9 @@ def test_builder_version_mismatch(tmp_path):
 
     package_json_path = extension_folder / "package.json"
 
-    # Modify the @jupyter/builder version to an incompatible range
+    # Modify the @jupyterlab/builder version to an incompatible range
     package_data = json.loads(package_json_path.read_text())
-    package_data["devDependencies"]["@jupyter/builder"] = "0.0.9"
+    package_data["devDependencies"]["@jupyterlab/builder"] = "4.0.0"
     package_json_path.write_text(json.dumps(package_data, indent=2))
 
     env = os.environ.copy()
@@ -289,7 +289,7 @@ def test_builder_version_mismatch(tmp_path):
     # This exercises the backwards-compatible version-check path.
     with pytest.raises(subprocess.CalledProcessError) as excinfo:
         run(
-            ["jupyter-builder", "build", str(extension_folder)],
+            ["jupyter-builder", "build", str(extension_folder), "--core-version", "4.5.x"],
             cwd=extension_folder,
             check=True,
             capture_output=True,
@@ -299,7 +299,7 @@ def test_builder_version_mismatch(tmp_path):
     assert re.search(
         (
             r"ValueError: Extensions require a devDependency on @jupyterlab/builder@\^.+?, "
-            r"you have a dependency on 0\.0\.9"
+            r"you have a dependency on 4\.0\.0"
         ),
         excinfo.value.stderr,
     ), "Expected version mismatch error message not found in output!"

--- a/tests/test_tpl.py
+++ b/tests/test_tpl.py
@@ -272,7 +272,7 @@ def test_builder_version_mismatch(tmp_path):
 
     # Modify the @jupyterlab/builder version to an incompatible range
     package_data = json.loads(package_json_path.read_text())
-    package_data["devDependencies"]["@jupyterlab/builder"] = "4.0.0"
+    package_data["devDependencies"]["@jupyterlab/builder"] = "3.0.0"
     package_json_path.write_text(json.dumps(package_data, indent=2))
 
     env = os.environ.copy()
@@ -299,7 +299,7 @@ def test_builder_version_mismatch(tmp_path):
     assert re.search(
         (
             r"ValueError: Extensions require a devDependency on @jupyterlab/builder@\^.+?, "
-            r"you have a dependency on 4\.0\.0"
+            r"you have a dependency on 3\.0\.0"
         ),
         excinfo.value.stderr,
     ), "Expected version mismatch error message not found in output!"

--- a/tests/test_tpl.py
+++ b/tests/test_tpl.py
@@ -108,6 +108,14 @@ def test_files_build_jupyterlab_builder(tmp_path):
     extension_folder.mkdir()
     helper(str(extension_folder))
 
+    pin_webpack = (
+        "const fs=require('fs');"
+        " const p=require('./package.json');"
+        " p.resolutions = p.resolutions || {};"
+        " p.resolutions.webpack='5.106.0';"
+        " fs.writeFileSync('package.json', JSON.stringify(p,null,2));"
+    )
+    run(["node", "-e", pin_webpack], cwd=extension_folder, check=True)
     env = os.environ.copy()
     env.update({"YARN_ENABLE_IMMUTABLE_INSTALLS": "false"})
     run(["jlpm", "install"], cwd=extension_folder, check=True, env=env)
@@ -206,6 +214,14 @@ def test_watch_functionality_jupyterlab_builder(tmp_path):
     extension_folder.mkdir()
     helper(str(extension_folder))
 
+    pin_webpack = (
+        "const fs=require('fs');"
+        " const p=require('./package.json');"
+        " p.resolutions = p.resolutions || {};"
+        " p.resolutions.webpack='5.106.0';"
+        " fs.writeFileSync('package.json', JSON.stringify(p,null,2));"
+    )
+    run(["node", "-e", pin_webpack], cwd=extension_folder, check=True)
     env = os.environ.copy()
     env.update({"YARN_ENABLE_IMMUTABLE_INSTALLS": "false"})
     run(["jlpm", "install"], cwd=extension_folder, check=True, env=env)

--- a/yarn.lock
+++ b/yarn.lock
@@ -193,7 +193,7 @@ __metadata:
   resolution: "@jupyter/builder@workspace:."
   dependencies:
     "@eslint/js": ^10.0.1
-    "@jupyterlab/core-meta": 4.6.0-alpha.4
+    "@jupyterlab/core-meta": 4.6.0-beta.0
     "@module-federation/runtime-tools": ^2.0.0
     "@rspack/core": ^2.0.2
     "@types/fs-extra": ^9.0.1
@@ -227,10 +227,10 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@jupyterlab/core-meta@npm:4.6.0-alpha.4":
-  version: 4.6.0-alpha.4
-  resolution: "@jupyterlab/core-meta@npm:4.6.0-alpha.4"
-  checksum: 9ee7870b1a5f41a15d20bddd716bb916bc65888bb08b6d8fe6f51d71b9d7110e701b37dd0ae3fc83342839c74555da6d7b49006c638fd32808269e3558324c06
+"@jupyterlab/core-meta@npm:4.6.0-beta.0":
+  version: 4.6.0-beta.0
+  resolution: "@jupyterlab/core-meta@npm:4.6.0-beta.0"
+  checksum: 6d063281cf03fd169f40ea6adbbc691f5cd3a4ef3fccf70ed6c1dd4175ffa85e6628427b2839b6d6a10bf0a9c8ade711798db8d5a7f27ee72d1446374b1a5f2c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Description

This was must before a stable v1 release. So that `@jupyterlab/core-meta` contains `@jupyter/builder v1`