### PR TITLE
Disable Yarn telemetry by default in `jlpm`

### DIFF
--- a/jupyter_builder/jlpm.py
+++ b/jupyter_builder/jlpm.py
@@ -63,4 +63,6 @@ def main(argv: list[str] | None = None) -> None:
     """Run node and return the result."""
     # Make sure node is available.
     argv = argv or sys.argv[1:]
+    # Disable Yarn telemetry by default for jlpm
+    os.environ.setdefault("YARN_ENABLE_TELEMETRY", "0")
     _execvp_node(["node", YARN_PATH, *argv])


### PR DESCRIPTION
## Fixes #114 

### Description

Yarn Berry ships with `enableTelemetry: true`, so jlpm has been quietly sending anonymous usage data to Yarn's servers. JupyterLab users install via pip/conda and never opt into Yarn directly, so they likely have no idea this is happening and there's a known bug where the telemetry ping can hang the CLI for several minutes on locked-down networks. (https://github.com/yarnpkg/berry/issues/6271)

This sets `YARN_ENABLE_TELEMETRY=0` as a default in the jlpm launcher, before we exec `node + yarn.js`.

Uses `os.environ.setdefault`, so it's a soft default and anyone who wants telemetry back can export `YARN_ENABLE_TELEMETRY=1`.
