### PR TITLE
Add Dependabot npm config to keep core-meta evergreen

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,3 +18,11 @@ updates:
       pip:
         patterns:
           - "*"
+  # JavaScript/TypeScript
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    versioning-strategy: increase
+    allow:
+      - dependency-name: "@jupyterlab/core-meta"


### PR DESCRIPTION
## Fixes #117 

### Description
Adds an `npm` ecosystem entry to Dependabot so `@jupyterlab/core-meta` gets bumped automatically.