### PR TITLE
Improve packages discovery

### DIFF
--- a/jupyter_builder/federated_extensions.py
+++ b/jupyter_builder/federated_extensions.py
@@ -517,11 +517,11 @@ def _valid_package_dirs(dirs: list[str]) -> list[str]:
 
 
 def _find_packages(path: str) -> list[str]:
-"""Find importable regular packages (dirs with ``__init__.py``) under *path*.
+    """Find importable regular packages (dirs with ``__init__.py``) under *path*.
 
-Recursion only continues into directories that are themselves regular packages.
-Also prunes non-identifier names and common non-source directories.
-"""
+    Recursion only continues into directories that are themselves regular packages.
+    Also prunes non-identifier names and common non-source directories.
+    """
     path_obj = Path(path)
     packages: list[str] = []
     for root, dirs, files in os.walk(str(path_obj), followlinks=True):

--- a/jupyter_builder/federated_extensions.py
+++ b/jupyter_builder/federated_extensions.py
@@ -506,29 +506,37 @@ def _get_labextension_dir(
     return labext
 
 
+# Directory names that are valid Python identifiers but never contain
+# importable extension source we care about.
+_SKIP_DIRS = frozenset({"__pycache__", "node_modules", "venv", "env"})
+
+
 def _valid_package_dirs(dirs: list[str]) -> list[str]:
     """Filter out dirs that can never be Python package components."""
-    return [d for d in dirs if "." not in d and d != "__pycache__"]
+    return [d for d in dirs if d.isidentifier() and d not in _SKIP_DIRS]
 
 
 def _find_packages(path: str) -> list[str]:
-    """Find Python packages (dirs with __init__.py), pruning __pycache__ and dotted names."""
+    """Find importable regular packages (dirs with ``__init__.py``) under *path*.
+
+    Mirrors ``setuptools.find_packages``.
+    """
     path_obj = Path(path)
-    packages = []
+    packages: list[str] = []
     for root, dirs, files in os.walk(str(path_obj), followlinks=True):
-        dirs[:] = _valid_package_dirs(dirs)
-        if "__init__.py" in files:
-            rel = Path(root).relative_to(path_obj)
-            if rel.parts:
-                packages.append(".".join(rel.parts))
+        # Only keep descending into subdirectories that are themselves
+        # packages; prune everything else.
+        dirs[:] = [
+            d for d in _valid_package_dirs(dirs) if (Path(root) / d / "__init__.py").is_file()
+        ]
+        rel = Path(root).relative_to(path_obj)
+        if rel.parts and "__init__.py" in files:
+            packages.append(".".join(rel.parts))
     return packages
 
 
 def _find_namespace_packages(path: str) -> list[str]:
-    """Find namespace packages (dirs with .py files, no __init__.py required).
-
-    Prunes __pycache__ and dotted names.
-    """
+    """Find namespace packages (dirs with .py files, no __init__.py required)."""
     path_obj = Path(path)
     found: set[str] = set()
     for root, dirs, files in os.walk(str(path_obj), followlinks=True):

--- a/jupyter_builder/federated_extensions.py
+++ b/jupyter_builder/federated_extensions.py
@@ -517,10 +517,11 @@ def _valid_package_dirs(dirs: list[str]) -> list[str]:
 
 
 def _find_packages(path: str) -> list[str]:
-    """Find importable regular packages (dirs with ``__init__.py``) under *path*.
+"""Find importable regular packages (dirs with ``__init__.py``) under *path*.
 
-    Mirrors ``setuptools.find_packages``.
-    """
+Recursion only continues into directories that are themselves regular packages.
+Also prunes non-identifier names and common non-source directories.
+"""
     path_obj = Path(path)
     packages: list[str] = []
     for root, dirs, files in os.walk(str(path_obj), followlinks=True):

--- a/tests/test_find_packages.py
+++ b/tests/test_find_packages.py
@@ -1,0 +1,62 @@
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+
+from pathlib import Path
+
+from jupyter_builder.federated_extensions import (
+    _find_namespace_packages,
+    _find_packages,
+    _valid_package_dirs,
+)
+
+
+def _touch(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("")
+
+
+def test_valid_package_dirs_keeps_only_identifier_non_vendored_dirs():
+    dirs = ["pkg", "node_modules", "__pycache__", "venv", "env", "ui-tests", ".hidden", "1bad"]
+    assert _valid_package_dirs(dirs) == ["pkg"]
+
+
+def test_find_packages_requires_init_py(tmp_path):
+    _touch(tmp_path / "pkg" / "__init__.py")
+    _touch(tmp_path / "pkg" / "sub" / "__init__.py")
+    # A dir without __init__.py is not a package and must be ignored.
+    _touch(tmp_path / "not_a_pkg" / "module.py")
+
+    assert sorted(_find_packages(str(tmp_path))) == ["pkg", "pkg.sub"]
+
+
+def test_find_packages_does_not_descend_into_non_package_parents(tmp_path):
+    # `inner` has an __init__.py but its parent `outer` does not, so it must
+    # not be reported (matches setuptools.find_packages semantics).
+    _touch(tmp_path / "outer" / "inner" / "__init__.py")
+
+    assert _find_packages(str(tmp_path)) == []
+
+
+def test_find_packages_skips_node_modules(tmp_path):
+    _touch(tmp_path / "pkg" / "__init__.py")
+    # Even if a node_modules subtree contains __init__.py files, it is skipped.
+    _touch(tmp_path / "node_modules" / "flatted" / "__init__.py")
+    _touch(tmp_path / "node_modules" / "flatted" / "python" / "__init__.py")
+
+    assert _find_packages(str(tmp_path)) == ["pkg"]
+
+
+def test_find_namespace_packages_finds_dirs_without_init_py(tmp_path):
+    # No __init__.py anywhere: still discovered as namespace packages.
+    _touch(tmp_path / "ns_pkg" / "module.py")
+    _touch(tmp_path / "ns_pkg" / "sub" / "module.py")
+
+    assert sorted(_find_namespace_packages(str(tmp_path))) == ["ns_pkg", "ns_pkg.sub"]
+
+
+def test_find_namespace_packages_skips_node_modules_and_non_identifiers(tmp_path):
+    _touch(tmp_path / "pkg" / "module.py")
+    _touch(tmp_path / "node_modules" / "flatted" / "python" / "module.py")
+    _touch(tmp_path / "ui-tests" / "conftest.py")
+
+    assert _find_namespace_packages(str(tmp_path)) == ["pkg"]


### PR DESCRIPTION
## Fixes #137 

`_find_packages` previously walked the entire source tree and treated any directory containing an `__init__.py` as a package, regardless of whether its parent directories were packages. This produced invalid package candidates such as `node_modules.flatted`.

This change aligns its behavior with `setuptools.find_packages`: recursion only continues into directories that are themselves Python packages (i.e., contain an `__init__.py`). As a result, non-package directory trees such as `node_modules` are skipped automatically.

This replaces the previous approach, which only filtered out dotted directory names.