### PR TITLE
Bump `@jupyterlab/core-meta` to v4.6.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "watch": "tsc -w --sourceMap"
   },
   "dependencies": {
-    "@jupyterlab/core-meta": "4.6.0",
+    "@jupyterlab/core-meta": "4.6.1",
     "@module-federation/runtime-tools": "^2.0.0",
     "@rspack/core": "^2.1.1",
     "ajv": "^8.12.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -193,7 +193,7 @@ __metadata:
   resolution: "@jupyter/builder@workspace:."
   dependencies:
     "@eslint/js": ^10.0.1
-    "@jupyterlab/core-meta": 4.6.0
+    "@jupyterlab/core-meta": 4.6.1
     "@module-federation/runtime-tools": ^2.0.0
     "@rspack/core": ^2.1.1
     "@types/fs-extra": ^9.0.1
@@ -225,10 +225,10 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@jupyterlab/core-meta@npm:4.6.0":
-  version: 4.6.0
-  resolution: "@jupyterlab/core-meta@npm:4.6.0"
-  checksum: c1a584fa6cb4b79c01bfce1d024eca4d1572f019b9600cd8fd614b1d9de1983c41313c3b9e49eb5f507d116137877f20989261c9b1350ad9a5b235b4cdecad5c
+"@jupyterlab/core-meta@npm:4.6.1":
+  version: 4.6.1
+  resolution: "@jupyterlab/core-meta@npm:4.6.1"
+  checksum: 8f91135b66806b65db81c4371dae36f794b476a869810b2c99ac243a94fc6a55a392a2dfbb2a93b5c225f4f45b5f50e43fa5641e68d15fa71db3c570cead161d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Because CI is failing on https://github.com/jupyterlab/jupyter-builder/pull/139