### PR TITLE
Pin packageManager to yarn 3.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "url": "https://github.com/jupyterlab/jupyter-builder/issues"
   },
   "license": "BSD-3-Clause",
+  "packageManager": "yarn@3.5.0",
   "author": {
     "name": "Jupyter Development Team",
     "email": "jupyter@googlegroups.com"


### PR DESCRIPTION
## References https://github.com/jupyterlab/jupyter-builder/pull/140#discussion_r3511245532

### Description

Dependabot npm PRs keep failing CI on the "Post-resolution validation" step because Dependabot regenerates `yarn.lock` with a different yarn version, which changes the TypeScript patch hash and trips the immutable install.

We use yarn 3.5.0 (via jlpm) but never told Dependabot that. Adding the `packageManager` field so it uses the same yarn and stops rewriting the lockfile.

```json
{
  "packageManager": "yarn@3.5.0"
}