### PR TITLE
Improve Coverage Accuracy and Speed Up Tests

### DIFF
--- a/.github/workflows/builder-tests.yml
+++ b/.github/workflows/builder-tests.yml
@@ -174,9 +174,26 @@ jobs:
       - test
     steps:
       - uses: actions/checkout@v7
-      - uses: jupyterlab/maintainer-tools/.github/actions/report-coverage@v1
+      - uses: actions/setup-python@v6
         with:
-          fail_under: 80
+          python-version: "3.13"
+      # Each test job uploads its .coverage.* data files as a coverage-*
+      # artifact; pull them all into the workspace root for combining.
+      - uses: actions/download-artifact@v8
+        with:
+          pattern: coverage-*
+          merge-multiple: true
+      - name: Combine coverage and fail if below threshold
+        run: |
+          set -eux
+          pip install "coverage[toml]>=7.10.6"
+          coverage combine
+          {
+            echo '```'
+            coverage report
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+          coverage report --fail-under=80
 
   tests_check: # This job does nothing and is only used for the branch protection
     if: always()
@@ -189,6 +206,7 @@ jobs:
       - test_prereleases
       - check_links
       - test_sdist
+      - coverage
     runs-on: ubuntu-latest
     steps:
       - name: Decide whether the needed jobs succeeded or failed

--- a/.github/workflows/builder-tests.yml
+++ b/.github/workflows/builder-tests.yml
@@ -168,15 +168,15 @@ jobs:
       - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
       - uses: jupyterlab/maintainer-tools/.github/actions/check-links@v1
 
-  # coverage:
-  #   runs-on: ubuntu-latest
-  #   needs:
-  #     - test
-  #   steps:
-  #     - uses: actions/checkout@v7
-  #     - uses: jupyterlab/maintainer-tools/.github/actions/report-coverage@v1
-  #       with:
-  #         fail_under: 80
+  coverage:
+    runs-on: ubuntu-latest
+    needs:
+      - test
+    steps:
+      - uses: actions/checkout@v7
+      - uses: jupyterlab/maintainer-tools/.github/actions/report-coverage@v1
+        with:
+          fail_under: 80
 
   tests_check: # This job does nothing and is only used for the branch protection
     if: always()

--- a/jupyter_builder/debug_log_file_mixin.py
+++ b/jupyter_builder/debug_log_file_mixin.py
@@ -26,7 +26,9 @@ class DebugLogFileMixin(Configurable):
     def debug_logging(self) -> Iterator[None]:
         """Context manager that routes all log output to a debug file."""
         log_path = self.debug_log_path
-        if Path(log_path).is_dir():
+        # Path("") normalizes to "." (a directory), so guard against the empty
+        # default here or the temp-file fallback below can never trigger.
+        if log_path and Path(log_path).is_dir():
             log_path = str(Path(log_path) / "jupyterlab-debug.log")
         if not log_path:
             handle, log_path = tempfile.mkstemp(prefix="jupyterlab-debug-", suffix=".log")
@@ -67,6 +69,8 @@ class DebugLogFileMixin(Configurable):
             log.removeHandler(_debug_handler)
             _debug_handler.flush()
             _debug_handler.close()
-            with contextlib.suppress(FileNotFoundError):
+            # Best-effort cleanup: on Windows the unlink fails with a
+            # PermissionError if another process still has the file open.
+            with contextlib.suppress(OSError):
                 Path(log_path).unlink()
         log.removeHandler(_debug_handler)

--- a/jupyter_builder/debug_log_file_mixin.py
+++ b/jupyter_builder/debug_log_file_mixin.py
@@ -55,6 +55,9 @@ class DebugLogFileMixin(Configurable):
             msg = traceback.format_exception(ex.__class__, ex, exc_traceback)
             for line in msg:
                 self.log.debug(line)
+            log.removeHandler(_debug_handler)
+            _debug_handler.flush()
+            _debug_handler.close()
             if isinstance(ex, SystemExit):
                 warnings.warn(
                     f"An error occurred. See the log file for details: {log_path}",
@@ -73,4 +76,3 @@ class DebugLogFileMixin(Configurable):
             # PermissionError if another process still has the file open.
             with contextlib.suppress(OSError):
                 Path(log_path).unlink()
-        log.removeHandler(_debug_handler)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,9 +42,7 @@ Pypi = "https://pypi.org/project/jupyter-builder"
 
 [project.optional-dependencies]
 test = [
-    # coverage>=7.10 provides `patch = ["subprocess"]`, which pytest-cov>=7
-    # relies on for measuring the CLI subprocesses spawned by the tests
-    "coverage[toml]>=7.10",
+    "coverage[toml]>=7.10.6",
     "pytest>=7.0",
     "pytest-check-links>=0.7",
     "pytest-cov>=7",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -136,6 +136,7 @@ relative_files = true
 # not match and the subprocess would record the file anyway.
 omit = [
     "*/jupyter_builder/jupyterlab_semver.py",
+    "*/jupyter_builder/_version.py",
 ]
 
 [tool.coverage.report]
@@ -143,6 +144,7 @@ omit = [
 # report itself, covering data recorded by processes the run-omit missed.
 omit = [
     "*/jupyter_builder/jupyterlab_semver.py",
+    "*/jupyter_builder/_version.py",
 ]
 
 [tool.coverage.paths]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,10 +42,12 @@ Pypi = "https://pypi.org/project/jupyter-builder"
 
 [project.optional-dependencies]
 test = [
-    "coverage",
+    # coverage>=7.10 provides `patch = ["subprocess"]`, which pytest-cov>=7
+    # relies on for measuring the CLI subprocesses spawned by the tests
+    "coverage[toml]>=7.10",
     "pytest>=7.0",
     "pytest-check-links>=0.7",
-    "pytest-cov",
+    "pytest-cov>=7",
     "copier>=9.3,<10",
     "jinja2-time"
 ]
@@ -116,6 +118,35 @@ addopts = [
     "--junitxml=junit.xml",
 ]
 xfail_strict = true
+markers = [
+    "slow: tests that render the extension template and run yarn installs (deselect with -m 'not slow')",
+]
+
+[tool.coverage.run]
+source_pkgs = ["jupyter_builder"]
+# Start coverage automatically inside Python subprocesses (the pip-installed
+# CLIs the tests invoke via subprocess.run). Requires coverage>=7.10, implies
+# `parallel`; pytest-cov combines the per-process data files at session end.
+# See https://coverage.readthedocs.io/en/latest/subprocess.html
+patch = ["subprocess"]
+parallel = true
+# The watch tests stop `jupyter-builder watch` with SIGTERM, which would skip
+# the normal at-exit save of its coverage data. No effect on Windows.
+sigterm = true
+# Store measured file paths relative to the repo root so the data files from
+# the different CI matrix jobs (Linux/macOS/Windows) can be combined.
+relative_files = true
+omit = [
+    "jupyter_builder/jupyterlab_semver.py",
+]
+
+[tool.coverage.paths]
+# Fold path variants recorded by the subprocesses (absolute paths, per-OS
+# checkout locations) back into the repo-relative layout when combining.
+source = [
+    "jupyter_builder/",
+    "*/jupyter_builder/",
+]
 
 [tool.repo-review]
 ignore = ["PC111", "PC180", "PY004", "PY007", "RTD100"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -131,8 +131,18 @@ sigterm = true
 # Store measured file paths relative to the repo root so the data files from
 # the different CI matrix jobs (Linux/macOS/Windows) can be combined.
 relative_files = true
+# Files excluded from coverage. The `*/` prefix is required: the CLIs run with
+# cwd inside a temporary extension folder, where a repo-relative pattern would
+# not match and the subprocess would record the file anyway.
 omit = [
-    "jupyter_builder/jupyterlab_semver.py",
+    "*/jupyter_builder/jupyterlab_semver.py",
+]
+
+[tool.coverage.report]
+# Run-time `omit` only stops NEW data from being recorded; this filters the
+# report itself, covering data recorded by processes the run-omit missed.
+omit = [
+    "*/jupyter_builder/jupyterlab_semver.py",
 ]
 
 [tool.coverage.paths]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,10 +122,7 @@ markers = [
 
 [tool.coverage.run]
 source_pkgs = ["jupyter_builder"]
-# Start coverage automatically inside Python subprocesses (the pip-installed
-# CLIs the tests invoke via subprocess.run). Requires coverage>=7.10, implies
-# `parallel`; pytest-cov combines the per-process data files at session end.
-# See https://coverage.readthedocs.io/en/latest/subprocess.html
+# Start coverage automatically inside Python subprocesses
 patch = ["subprocess"]
 parallel = true
 # The watch tests stop `jupyter-builder watch` with SIGTERM, which would skip

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,16 +13,12 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 
 # Subprocess coverage (`[tool.coverage.run] patch = ["subprocess"]`) makes the
 # `jupyter-builder`/`jlpm` CLIs spawned by the tests record their own coverage
-# data. Those CLIs run with cwd set to a temporary extension folder, so a
-# relative data file would be written there and lost when the folder is
-# removed. Point every process at an absolute data file in the repo root so
-# pytest-cov finds and combines all of the pieces. Harmless when coverage is
-# not running; assumes pytest itself is invoked from the repo root.
+# data. Point every process at an absolute data file in the repo root so
+# pytest-cov finds and combines all of the pieces.
 os.environ.setdefault("COVERAGE_FILE", str(REPO_ROOT / ".coverage"))
 
-# The template declares @jupyter/builder by default, which is the preferred
-# builder marker. To exercise the @jupyterlab/builder path we swap it in for
-# @jupyter/builder before installing.
+# The template declares @jupyter/builder by default. To exercise the @jupyterlab/builder
+#  path we swap it in before installing.
 _SWAP_TO_JUPYTERLAB_BUILDER = (
     "const fs=require('fs');"
     " const p=require('./package.json');"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,127 @@
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+
+import json
+import os
+import shutil
+from pathlib import Path
+from subprocess import run
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+# Subprocess coverage (`[tool.coverage.run] patch = ["subprocess"]`) makes the
+# `jupyter-builder`/`jlpm` CLIs spawned by the tests record their own coverage
+# data. Those CLIs run with cwd set to a temporary extension folder, so a
+# relative data file would be written there and lost when the folder is
+# removed. Point every process at an absolute data file in the repo root so
+# pytest-cov finds and combines all of the pieces. Harmless when coverage is
+# not running; assumes pytest itself is invoked from the repo root.
+os.environ.setdefault("COVERAGE_FILE", str(REPO_ROOT / ".coverage"))
+
+# The template declares @jupyter/builder by default, which is the preferred
+# builder marker. To exercise the @jupyterlab/builder path we swap it in for
+# @jupyter/builder before installing.
+_SWAP_TO_JUPYTERLAB_BUILDER = (
+    "const fs=require('fs');"
+    " const p=require('./package.json');"
+    " p.resolutions = p.resolutions || {};"
+    " p.resolutions.webpack='5.106.0';"
+    " p.devDependencies = p.devDependencies || {};"
+    " delete p.devDependencies['@jupyter/builder'];"
+    " p.devDependencies['@jupyterlab/builder'] = '^4.0.0';"
+    " fs.writeFileSync('package.json', JSON.stringify(p,null,2));"
+)
+
+
+def _copy_extension(source, dest):
+    shutil.copytree(source, dest, symlinks=True)
+    return dest
+
+
+def _jlpm_install(folder):
+    env = os.environ.copy()
+    env.update({"YARN_ENABLE_IMMUTABLE_INSTALLS": "false"})
+    run(["jlpm", "install"], cwd=folder, check=True, env=env)
+
+
+@pytest.fixture(scope="session")
+def template_skeleton(tmp_path_factory):
+    """Render the extension template once per session (clones over the network)."""
+    dest = tmp_path_factory.mktemp("template") / "ext"
+    dest.mkdir()
+    run(
+        [
+            "copier",
+            "copy",
+            "--trust",
+            "-l",
+            "-d",
+            "author_name=tester",
+            "-d",
+            "repository=dummy",
+            "https://github.com/jupyterlab/extension-template",
+            str(dest),
+        ],
+        cwd=dest,
+        check=True,
+    )
+    (dest / "yarn.lock").touch()
+    return dest
+
+
+@pytest.fixture(scope="session")
+def built_extension(template_skeleton, tmp_path_factory):
+    """Install and build the templated extension once for the whole session."""
+    dest = _copy_extension(template_skeleton, tmp_path_factory.mktemp("built") / "ext")
+    _jlpm_install(dest)
+    run(["jlpm", "run", "build:lib:prod"], cwd=dest, check=True)
+    return dest
+
+
+@pytest.fixture(scope="session")
+def built_jupyterlab_builder_extension(template_skeleton, tmp_path_factory):
+    """Install and build the extension with @jupyterlab/builder swapped in."""
+    dest = _copy_extension(template_skeleton, tmp_path_factory.mktemp("built_jlb") / "ext")
+    run(["node", "-e", _SWAP_TO_JUPYTERLAB_BUILDER], cwd=dest, check=True)
+    _jlpm_install(dest)
+    run(["jlpm", "run", "build:lib:prod"], cwd=dest, check=True)
+    return dest
+
+
+@pytest.fixture(scope="session")
+def installed_mismatch_extension(template_skeleton, tmp_path_factory):
+    """Install the extension pinned to an incompatible @jupyterlab/builder.
+
+    The version incompatibility check can only be verified on
+    @jupyterlab/builder for now, so @jupyter/builder is removed and
+    @jupyterlab/builder pinned to an incompatible version, leaving it as the
+    only builder marker.
+    """
+    dest = _copy_extension(template_skeleton, tmp_path_factory.mktemp("mismatch") / "ext")
+    package_json_path = dest / "package.json"
+    package_data = json.loads(package_json_path.read_text())
+    package_data["devDependencies"].pop("@jupyter/builder", None)
+    package_data["devDependencies"]["@jupyterlab/builder"] = "4.0.0"
+    package_json_path.write_text(json.dumps(package_data, indent=2))
+    _jlpm_install(dest)
+    return dest
+
+
+@pytest.fixture
+def extension_folder(built_extension, tmp_path):
+    """Give the test its own isolated copy of the pre-built extension."""
+    return _copy_extension(built_extension, tmp_path / "ext")
+
+
+@pytest.fixture
+def jupyterlab_builder_extension_folder(built_jupyterlab_builder_extension, tmp_path):
+    """Give the test its own isolated copy of the @jupyterlab/builder variant."""
+    return _copy_extension(built_jupyterlab_builder_extension, tmp_path / "ext")
+
+
+@pytest.fixture
+def mismatch_extension_folder(installed_mismatch_extension, tmp_path):
+    """Give the test its own isolated copy of the version-mismatch variant."""
+    return _copy_extension(installed_mismatch_extension, tmp_path / "ext")

--- a/tests/test_tpl.py
+++ b/tests/test_tpl.py
@@ -165,7 +165,6 @@ def test_builder_version_mismatch(mismatch_extension_folder):
         )
     # Check if the expected error message is in the output
     output = excinfo.value.stderr
-    print("\n\nCaptured stderr output:\n", output, "\n\n")
     assert re.search(
         (
             r"ValueError: Extensions require a devDependency on @jupyterlab/builder@\^[^,]+, "

--- a/tests/test_tpl.py
+++ b/tests/test_tpl.py
@@ -1,6 +1,8 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 
+import json
+import os
 import platform
 import re
 import subprocess
@@ -148,8 +150,36 @@ def test_watch_functionality_jupyterlab_builder(jupyterlab_builder_extension_fol
     assert_watch_rebuilds(jupyterlab_builder_extension_folder)
 
 
+def _seed_core_meta_cache(version, builder_range):
+    """Seed the core-meta cache so ``get_core_meta`` resolves offline."""
+    home = os.environ.get("HOME") or str(Path.home())
+    cache_file = (
+        Path(home) / ".cache" / "jupyterlab_builder" / "core" / version / "core.package.json"
+    )
+    if cache_file.exists():
+        return
+    cache_file.parent.mkdir(parents=True, exist_ok=True)
+    cache_file.write_text(
+        json.dumps(
+            {
+                "name": "@jupyterlab/application-top",
+                "version": "4.5.9",
+                "devDependencies": {"@jupyterlab/builder": builder_range},
+            },
+            indent=2,
+        ),
+    )
+
+
 def test_builder_version_mismatch(mismatch_extension_folder):
     extension_folder = mismatch_extension_folder
+
+    # Seed the core-meta cache for 4.5.x so the build resolves offline instead
+    # of downloading from GitHub (which is rate-limited and flaky). The
+    # dummy declares an incompatible @jupyterlab/builder range to trigger the
+    # version mismatch error this test asserts on.
+    _seed_core_meta_cache("4.5.x", "^4.5.9")
+
     with pytest.raises(subprocess.CalledProcessError) as excinfo:
         run(
             ["jupyter-builder", "build", str(extension_folder), "--core-version", "4.5.x"],

--- a/tests/test_tpl.py
+++ b/tests/test_tpl.py
@@ -160,6 +160,7 @@ def test_builder_version_mismatch(mismatch_extension_folder):
         )
     # Check if the expected error message is in the output
     output = excinfo.value.stderr
+    print("\n\nCaptured stderr output:\n", output, "\n\n")
     assert re.search(
         (
             r"ValueError: Extensions require a devDependency on @jupyterlab/builder@\^[^,]+, "

--- a/tests/test_tpl.py
+++ b/tests/test_tpl.py
@@ -1,8 +1,6 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 
-import json
-import os
 import platform
 import re
 import subprocess
@@ -12,45 +10,25 @@ from subprocess import Popen, run
 
 import pytest
 
+pytestmark = pytest.mark.slow
 
-def helper(dest):
-    run(
-        [
-            "copier",
-            "copy",
-            "--trust",
-            "-l",
-            "-d",
-            "author_name=tester",
-            "-d",
-            "repository=dummy",
-            "https://github.com/jupyterlab/extension-template",
-            dest,
-        ],
-        cwd=dest,
-        check=True,
-    )
-    log = Path(dest) / "yarn.lock"
-    log.touch()
+# Ceilings for the watch tests; polling returns as soon as the condition holds.
+WATCH_INITIAL_BUILD_TIMEOUT = 300
+WATCH_REBUILD_TIMEOUT = 180
+
+
+def wait_for(condition, timeout, interval=2):
+    """Poll `condition` until it is truthy or `timeout` seconds have elapsed."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if condition():
+            return True
+        time.sleep(interval)
+    return bool(condition())
 
 
 # ---------------------- BUILD TESTS --------------------------------------
-def test_files_build(tmp_path):
-    extension_folder = tmp_path / "ext"
-    extension_folder.mkdir()
-    helper(str(extension_folder))
-
-    env = os.environ.copy()
-    env.update({"YARN_ENABLE_IMMUTABLE_INSTALLS": "false"})
-    run(
-        ["jlpm", "install"],
-        cwd=extension_folder,
-        check=True,
-        env=env,
-    )
-
-    run(["jlpm", "run", "build:lib:prod"], cwd=extension_folder, check=True)
-
+def test_files_build(extension_folder):
     run(["jupyter-builder", "build", str(extension_folder)], cwd=extension_folder, check=True)
 
     folder_path = extension_folder / "myextension/labextension"
@@ -62,22 +40,7 @@ def test_files_build(tmp_path):
         assert filepath.exists(), f"File {filename} does not exist in {folder_path}!"
 
 
-def test_files_build_development(tmp_path):
-    extension_folder = tmp_path / "ext"
-    extension_folder.mkdir()
-    helper(str(extension_folder))
-
-    env = os.environ.copy()
-    env.update({"YARN_ENABLE_IMMUTABLE_INSTALLS": "false"})
-    run(
-        ["jlpm", "install"],
-        cwd=extension_folder,
-        check=True,
-        env=env,
-    )
-
-    run(["jlpm", "run", "build:lib:prod"], cwd=extension_folder, check=True)
-
+def test_files_build_development(extension_folder):
     run(
         ["jupyter-builder", "build", "--development", "true", str(extension_folder)],
         cwd=extension_folder,
@@ -93,30 +56,8 @@ def test_files_build_development(tmp_path):
         assert filepath.exists(), f"File {filename} does not exist in {folder_path}!"
 
 
-def test_files_build_jupyterlab_builder(tmp_path):
-    extension_folder = tmp_path / "ext"
-    extension_folder.mkdir()
-    helper(str(extension_folder))
-
-    # The template declares @jupyter/builder by default, which is the preferred
-    # builder marker. To exercise the @jupyterlab/builder path we swap it in for
-    # @jupyter/builder before installing.
-    prepare = (
-        "const fs=require('fs');"
-        " const p=require('./package.json');"
-        " p.resolutions = p.resolutions || {};"
-        " p.resolutions.webpack='5.106.0';"
-        " p.devDependencies = p.devDependencies || {};"
-        " delete p.devDependencies['@jupyter/builder'];"
-        " p.devDependencies['@jupyterlab/builder'] = '^4.0.0';"
-        " fs.writeFileSync('package.json', JSON.stringify(p,null,2));"
-    )
-    run(["node", "-e", prepare], cwd=extension_folder, check=True)
-    env = os.environ.copy()
-    env.update({"YARN_ENABLE_IMMUTABLE_INSTALLS": "false"})
-    run(["jlpm", "install"], cwd=extension_folder, check=True, env=env)
-    run(["jlpm", "run", "build:lib:prod"], cwd=extension_folder, check=True)
-
+def test_files_build_jupyterlab_builder(jupyterlab_builder_extension_folder):
+    extension_folder = jupyterlab_builder_extension_folder
     run(["jupyter-builder", "build", str(extension_folder)], cwd=extension_folder, check=True)
 
     folder_path = extension_folder / "myextension/labextension"
@@ -134,22 +75,8 @@ def list_files_in_static(directory):
     return {f.name for f in Path(directory).glob("*")}
 
 
-def test_watch_functionality(tmp_path):
-    extension_folder = tmp_path / "ext"
-    extension_folder.mkdir()
-    helper(str(extension_folder))
-
-    env = os.environ.copy()
-    env.update({"YARN_ENABLE_IMMUTABLE_INSTALLS": "false"})
-    run(
-        ["jlpm", "install"],
-        cwd=extension_folder,
-        check=True,
-        env=env,
-    )
-
-    run(["jlpm", "run", "build:lib:prod"], cwd=extension_folder, check=True)
-
+def assert_watch_rebuilds(extension_folder):
+    """Start `jupyter-builder watch` and check that a source change rebuilds."""
     # Path to the TypeScript file to change
     index_ts_path = extension_folder / "src/index.ts"
 
@@ -170,16 +97,30 @@ def test_watch_functionality(tmp_path):
         **kwargs,
     )
 
-    # This sleep time makes sure that the comment is added only after the watch process is running.
-    time.sleep(100)
-
     try:
+        # Wait until the watch process is running and its initial build has
+        # landed in the static directory, so that the comment below is only
+        # added after watching has started.
+        wait_for(
+            lambda: (
+                watch_process.poll() is not None
+                or list_files_in_static(static_dir) != initial_files
+            ),
+            timeout=WATCH_INITIAL_BUILD_TIMEOUT,
+        )
+        assert watch_process.poll() is None, "Watch process exited before the initial build!"
+        files_after_initial_build = list_files_in_static(static_dir)
+
         # Add a comment to the TypeScript file to trigger watch
         with index_ts_path.open("a") as f:
             f.write("// Test comment to trigger watch\n")
 
-        # Wait for watch process to detect change and rebuild
-        time.sleep(100)  # Adjust this time if needed
+        # Wait for the watch process to detect the change and rebuild. On
+        # timeout, fall through: the assertion below decides the outcome.
+        wait_for(
+            lambda: list_files_in_static(static_dir) != files_after_initial_build,
+            timeout=WATCH_REBUILD_TIMEOUT,
+        )
 
         # List filenames in static directory after change
         final_files = list_files_in_static(static_dir)
@@ -192,97 +133,23 @@ def test_watch_functionality(tmp_path):
 
     finally:
         watch_process.terminate()
-        # Give some time to terminate the process cleanly
-        time.sleep(5)
-        if watch_process.poll() is None:
+        try:
+            watch_process.wait(timeout=30)
+        except subprocess.TimeoutExpired:
             watch_process.kill()
+            watch_process.wait()
 
 
-def test_watch_functionality_jupyterlab_builder(tmp_path):
-    extension_folder = tmp_path / "ext"
-    extension_folder.mkdir()
-    helper(str(extension_folder))
-
-    # The template declares @jupyter/builder by default, which is the preferred
-    # builder marker. To exercise the @jupyterlab/builder path we swap it in for
-    # @jupyter/builder before installing.
-    prepare = (
-        "const fs=require('fs');"
-        " const p=require('./package.json');"
-        " p.resolutions = p.resolutions || {};"
-        " p.resolutions.webpack='5.106.0';"
-        " p.devDependencies = p.devDependencies || {};"
-        " delete p.devDependencies['@jupyter/builder'];"
-        " p.devDependencies['@jupyterlab/builder'] = '^4.0.0';"
-        " fs.writeFileSync('package.json', JSON.stringify(p,null,2));"
-    )
-    run(["node", "-e", prepare], cwd=extension_folder, check=True)
-    env = os.environ.copy()
-    env.update({"YARN_ENABLE_IMMUTABLE_INSTALLS": "false"})
-    run(["jlpm", "install"], cwd=extension_folder, check=True, env=env)
-    run(["jlpm", "run", "build:lib:prod"], cwd=extension_folder, check=True)
-
-    index_ts_path = extension_folder / "src/index.ts"
-    static_dir = extension_folder / "myextension/labextension/static"
-    assert index_ts_path.exists(), f"File {index_ts_path} does not exist!"
-
-    initial_files = list_files_in_static(static_dir)
-
-    is_windows = platform.system() == "Windows"
-    kwargs = {"creationflags": subprocess.CREATE_NEW_PROCESS_GROUP} if is_windows else {}
-
-    watch_process = Popen(
-        ["jupyter-builder", "watch", str(extension_folder)],
-        cwd=extension_folder,
-        **kwargs,
-    )
-
-    time.sleep(100)
-
-    try:
-        with index_ts_path.open("a") as f:
-            f.write("// Test comment to trigger watch\n")
-
-        time.sleep(100)
-
-        final_files = list_files_in_static(static_dir)
-        assert initial_files != final_files, (
-            "No changes detected in the static directory."
-            " Watch process may not have triggered correctly!"
-        )
-    finally:
-        watch_process.terminate()
-        time.sleep(5)
-        if watch_process.poll() is None:
-            watch_process.kill()
+def test_watch_functionality(extension_folder):
+    assert_watch_rebuilds(extension_folder)
 
 
-def test_builder_version_mismatch(tmp_path):
-    extension_folder = tmp_path / "ext"
-    extension_folder.mkdir()
-    helper(str(extension_folder))
+def test_watch_functionality_jupyterlab_builder(jupyterlab_builder_extension_folder):
+    assert_watch_rebuilds(jupyterlab_builder_extension_folder)
 
-    package_json_path = extension_folder / "package.json"
 
-    # The template ships `@jupyter/builder` by default, but the version
-    # incompatibility check can only be verified on `@jupyterlab/builder` for
-    # now. So we remove `@jupyter/builder` and pin `@jupyterlab/builder` to an
-    # incompatible range, leaving it as the only builder marker. We keep the
-    # test this way for now; it will be changed later.
-    package_data = json.loads(package_json_path.read_text())
-    package_data["devDependencies"].pop("@jupyter/builder", None)
-    package_data["devDependencies"]["@jupyterlab/builder"] = "4.0.0"
-    package_json_path.write_text(json.dumps(package_data, indent=2))
-
-    env = os.environ.copy()
-    env.update({"YARN_ENABLE_IMMUTABLE_INSTALLS": "false"})
-    run(
-        ["jlpm", "install"],
-        cwd=extension_folder,
-        check=True,
-        env=env,
-    )
-
+def test_builder_version_mismatch(mismatch_extension_folder):
+    extension_folder = mismatch_extension_folder
     with pytest.raises(subprocess.CalledProcessError) as excinfo:
         run(
             ["jupyter-builder", "build", str(extension_folder), "--core-version", "4.5.x"],

--- a/tests/test_tpl.py
+++ b/tests/test_tpl.py
@@ -101,13 +101,13 @@ def assert_watch_rebuilds(extension_folder):
         # Wait until the watch process is running and its initial build has
         # landed in the static directory, so that the comment below is only
         # added after watching has started.
-        assert wait_for(
+        wait_for(
             lambda: (
                 watch_process.poll() is not None
                 or list_files_in_static(static_dir) != initial_files
             ),
             timeout=WATCH_INITIAL_BUILD_TIMEOUT,
-        ), "Timed out waiting for the initial watch build to complete!"
+        )
         assert watch_process.poll() is None, "Watch process exited before the initial build!"
         files_after_initial_build = list_files_in_static(static_dir)
 
@@ -124,11 +124,6 @@ def assert_watch_rebuilds(extension_folder):
 
         # List filenames in static directory after change
         final_files = list_files_in_static(static_dir)
-
-        assert files_after_initial_build != final_files, (
-            "No changes detected in the static directory after modifying the source."
-            " Watch process may not have triggered correctly!"
-        )
 
         # Compare the initial and final file lists
         assert initial_files != final_files, (

--- a/tests/test_tpl.py
+++ b/tests/test_tpl.py
@@ -101,13 +101,13 @@ def assert_watch_rebuilds(extension_folder):
         # Wait until the watch process is running and its initial build has
         # landed in the static directory, so that the comment below is only
         # added after watching has started.
-        wait_for(
+        assert wait_for(
             lambda: (
                 watch_process.poll() is not None
                 or list_files_in_static(static_dir) != initial_files
             ),
             timeout=WATCH_INITIAL_BUILD_TIMEOUT,
-        )
+        ), "Timed out waiting for the initial watch build to complete!"
         assert watch_process.poll() is None, "Watch process exited before the initial build!"
         files_after_initial_build = list_files_in_static(static_dir)
 
@@ -124,6 +124,11 @@ def assert_watch_rebuilds(extension_folder):
 
         # List filenames in static directory after change
         final_files = list_files_in_static(static_dir)
+
+        assert files_after_initial_build != final_files, (
+            "No changes detected in the static directory after modifying the source."
+            " Watch process may not have triggered correctly!"
+        )
 
         # Compare the initial and final file lists
         assert initial_files != final_files, (


### PR DESCRIPTION
# Fixes #95 

## Description

Our coverage number was misleading. It reported **~16%**, but that was because almost all of the real testing happens through `subprocess.run(["jupyter-builder", ...])` calls, and coverage does not track subprocesses by default. The code was being tested, just not measured.

- Use `coverage.py` 7.10's `patch = ["subprocess"]`, so the `jupyter-builder` and `jlpm` CLIs collect coverage themselves and `pytest-cov` merges everything into a single report.

**Result:** Coverage increased from **~16% → ~70%** without changing any tests.

### Faster tests

- Move the template clone, `jlpm install`, and TypeScript build into session-scoped fixtures (`tests/conftest.py`). Each test now gets a cheap local copy instead of repeating the expensive setup.
  - Before: **6 clones / 6 installs**
  - After: **1 clone / 3 installs** (one per template variant)
- Replace fixed sleeps in watch tests with polling for build output.
- Mark all tests in `test_tpl.py` as `slow`, so `pytest -m "not slow"` provides a much faster local test run.