### PR TITLE
Add `py.typed`

### DIFF
--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -23,6 +23,7 @@ header:
     - 'jupyter_builder/yarn.js'
     - 'jupyter_builder/_version.py'
     - 'jupyter_builder/jupyterlab_semver.py'
+    - 'jupyter_builder/py.typed'
     - THIRD_PARTY_LICENSES/**
 
   comment: on-failure


### PR DESCRIPTION
## references
- for https://github.com/jupyterlab/jupyterlab/issues/19057

## changes
- [x] add `py.typed` marker file for [PEP-561](https://peps.python.org/pep-0561/)
  - > by inspection, this is ending up in the `.tar.gz` and `.whl`; it seems like modern `hatchling` doesn't need any extra metadata :tada: 
- [x] ignore `py.typed` in `.licenserc.yaml`