### PR TITLE
Do not resolve symlinks when locating `node`, fixing Volta-style shims

### DIFF
--- a/jupyter_builder/jlpm.py
+++ b/jupyter_builder/jlpm.py
@@ -40,7 +40,11 @@ def _which_node_js(env: dict[str, str] | None = None) -> str:
             "(https://nodejs.org)."
         )
         raise ValueError(msg)
-    return str(Path(command_with_path).resolve())
+    # Return the path as found on PATH, without resolving symlinks: version
+    # managers such as Volta install `node` as a symlink to a dispatcher
+    # binary that selects the tool from the name it is invoked under, so the
+    # dispatch only works when the command keeps the `node` name.
+    return command_with_path
 
 
 def _execvp_node(argv: list[str]) -> None:

--- a/tests/test_jlpm.py
+++ b/tests/test_jlpm.py
@@ -1,0 +1,24 @@
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+
+import sys
+
+import pytest
+
+from jupyter_builder.jlpm import _which_node_js
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="requires POSIX symlinks")
+def test_which_node_js_returns_symlink_path_unresolved(tmp_path):
+    # Mimic a Volta-style setup where `node` is a symlink to a dispatcher
+    # binary.
+    dispatcher = tmp_path / "dispatcher"
+    dispatcher.write_text("#!/bin/sh\n")
+    dispatcher.chmod(0o755)
+
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    node_shim = bin_dir / "node"
+    node_shim.symlink_to(dispatcher)
+
+    assert _which_node_js(env={"PATH": str(bin_dir)}) == str(node_shim)


### PR DESCRIPTION
Investigating some issues locally when using Node via [Volta](https://volta.sh/) with `jupyter-builder>=1.1.0`