### PR TITLE
Add deptry to CI to catch missing/transitive dependencies

### DIFF
--- a/.github/workflows/builder-tests.yml
+++ b/.github/workflows/builder-tests.yml
@@ -107,6 +107,8 @@ jobs:
         run: |
           python -m pre_commit run --all
           # pipx run interrogate -v .
+      - name: Check dependencies with deptry
+        run: deptry .
 
   test_minimum_versions:
     name: Test Minimum Versions

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,10 +47,11 @@ test = [
     "pytest-check-links>=0.7",
     "pytest-cov",
     "copier>=9.3,<10",
-    "jinja2-time"
+    "jinja2-time",
+    "deptry"
 ]
 # Check ruff version is aligned with the one in .pre-commit-config.yaml
-dev = ["build", "mypy", "pre-commit", "hatch", "ruff==0.15.20", "deptry"]
+dev = ["build", "mypy", "pre-commit", "hatch", "ruff==0.15.20"]
 
 [project.scripts]
 jupyter-builder = "jupyter_builder.main:main"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ test = [
     "jinja2-time"
 ]
 # Check ruff version is aligned with the one in .pre-commit-config.yaml
-dev = ["build", "mypy", "pre-commit", "hatch", "ruff==0.15.20"]
+dev = ["build", "mypy", "pre-commit", "hatch", "ruff==0.15.20", "deptry"]
 
 [project.scripts]
 jupyter-builder = "jupyter_builder.main:main"
@@ -58,6 +58,28 @@ jlpm = "jupyter_builder.jlpm:main"
 
 [tool.check-wheel-contents]
 ignore = ["W002", "W004"]
+
+[tool.deptry]
+# Default exclude list skips "tests"; un-skip it so test-only deps (pytest,
+# copier, ...) are checked too, since that's most of what [project.optional-dependencies.test] declares.
+exclude = ["venv", "\\.venv", "\\.direnv", "\\.git", "setup\\.py", "scripts"]
+
+[tool.deptry.per_rule_ignores]
+# CLI tools / pytest plugins that are invoked via subprocess or auto-discovered
+# entry points rather than imported directly, so deptry can't see their usage.
+DEP002 = [
+    "build",
+    "coverage",
+    "copier",
+    "deptry",
+    "hatch",
+    "jinja2-time",
+    "mypy",
+    "pre-commit",
+    "pytest-check-links",
+    "pytest-cov",
+    "ruff",
+]
 
 [tool.hatch.version]
 source = "nodejs"


### PR DESCRIPTION
## Fixes #84 

### Description

Wired `deptry` into the existing `test_lint` job

`scripts/` is excluded from scanning, so the `click`/`packaging`/`jupyter_releaser` imports in `bump_version.py` aren't flagged.

suppressed the remaining CLI-only/plugin tools (`ruff`, `mypy`, etc) via `per_rule_ignores` for DEP002 only, since they're invoked via subprocess/entry points and never imported.

No first-party import misfired.