### PR TITLE
Fix flaky `test_builder_version_mismatch`

### DIFF
--- a/tests/test_tpl.py
+++ b/tests/test_tpl.py
@@ -257,10 +257,37 @@ def test_watch_functionality_jupyterlab_builder(tmp_path):
             watch_process.kill()
 
 
+def _seed_core_meta_cache(version, builder_range):
+    """Seed the core-meta cache so ``get_core_meta`` resolves offline."""
+    home = os.environ.get("HOME") or str(Path.home())
+    cache_file = (
+        Path(home) / ".cache" / "jupyterlab_builder" / "core" / version / "core.package.json"
+    )
+    if cache_file.exists():
+        return
+    cache_file.parent.mkdir(parents=True, exist_ok=True)
+    cache_file.write_text(
+        json.dumps(
+            {
+                "name": "@jupyterlab/application-top",
+                "version": "4.5.9",
+                "devDependencies": {"@jupyterlab/builder": builder_range},
+            },
+            indent=2,
+        ),
+    )
+
+
 def test_builder_version_mismatch(tmp_path):
     extension_folder = tmp_path / "ext"
     extension_folder.mkdir()
     helper(str(extension_folder))
+
+    # Seed the core-meta cache for 4.5.x so the build resolves offline instead
+    # of downloading from GitHub (which is rate-limited and flaky). The
+    # dummy declares an incompatible @jupyterlab/builder range to trigger the
+    # version mismatch error this test asserts on.
+    _seed_core_meta_cache("4.5.x", "^4.5.9")
 
     package_json_path = extension_folder / "package.json"
 


### PR DESCRIPTION
## Fixes #148 

### Description

This test kept failing with HTTP 403: rate limit exceeded because `--core-version 4.5.x` isn't on npm, so it fell back to downloading `core-meta` from GitHub, which is rate-limited in CI.

`get_core_meta` checks the local cache before hitting the network, so the test now seeds a minimal dummy `core.package.json` for `4.5.x` before the build. It declares an incompatible `@jupyterlab/builder` version range (same as in real core meta file for `4.5.x`), which is all the test needs to trigger the version-mismatch error. This avoids all network access and eliminates the flake.