### PR TITLE
Improve fallback resolution

### DIFF
--- a/jupyter_builder/core_path.py
+++ b/jupyter_builder/core_path.py
@@ -12,6 +12,8 @@ import subprocess
 import tarfile
 import urllib.error
 import urllib.request
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as installed_version
 from pathlib import Path
 
 from .constants import JPBLD_NPM_URL, JPBLD_RAW_GITHUB_URL
@@ -28,6 +30,9 @@ _GITHUB_LATEST_RELEASE_API_URL = (
 
 #: Upper bound on tag-list pages fetched when resolving a wildcard (100 tags per page)
 _MAX_GITHUB_TAG_PAGES = 10
+
+#: Pre-migration marker package.
+_LEGACY_BUILDER_MARKER = "@jupyterlab/builder"
 
 
 def _home_dir() -> Path:
@@ -53,23 +58,16 @@ def get_core_meta(
     logger: logging.Logger | None = None,
 ) -> str:
     """Return the path to the core package JSON, downloading it if needed."""
-    requested_version = version
-    if requested_version is None:
-        if ext_path is not None:
-            installed_core_meta = _get_installed_core_meta(Path(ext_path).resolve())
-            if installed_core_meta is not None:
-                return installed_core_meta
-            if logger:
-                logger.warning(
-                    "\033[33m@jupyterlab/core-meta was not found in node_modules, "
-                    "so a network download will be used as a fallback. To avoid this, "
-                    "add @jupyter/builder as a devDependency instead of "
-                    "@jupyterlab/builder.\n \033[0m",
-                )
-        requested_version = "latest"
-    else:
+    if version is not None:
         # Accept both "vX.Y.Z" and "X.Y.Z" for an explicitly requested version.
-        requested_version = _normalize_version(requested_version)
+        requested_version = _normalize_version(version)
+        used_fallback_resolution = False
+    else:
+        installed_core_meta, requested_version, used_fallback_resolution = (
+            _resolve_version_without_installed_core_meta(ext_path, logger)
+        )
+        if installed_core_meta is not None:
+            return installed_core_meta
 
     cache_root = _home_dir() / ".cache" / "jupyterlab_builder" / "core"
     cached_file = _get_cached_core_meta_file(cache_root, requested_version)
@@ -80,6 +78,7 @@ def get_core_meta(
     # requested version cannot be found in either source, raise an error.
     try:
         npm_version = _resolve_npm_version(requested_version)
+        _check_matches_installed_jupyterlab(npm_version, used_fallback_resolution, logger)
         npm_cache_file = cache_root / npm_version / "core.package.json"
         if npm_cache_file.exists():
             return str(npm_cache_file)
@@ -88,6 +87,7 @@ def get_core_meta(
     except urllib.error.URLError as npm_error:
         try:
             github_version = _resolve_github_version(requested_version)
+            _check_matches_installed_jupyterlab(github_version, used_fallback_resolution, logger)
             github_cache_file = cache_root / github_version / "core.package.json"
             if github_cache_file.exists():
                 return str(github_cache_file)
@@ -104,9 +104,100 @@ def get_core_meta(
         return str(github_cache_file)
 
 
+def _resolve_version_without_installed_core_meta(
+    ext_path: str | os.PathLike[str] | None,
+    logger: logging.Logger | None,
+) -> tuple[str | None, str, bool]:
+    """Resolve a version when no explicit `version` was given.
+
+    Returns `(installed_core_meta_path, requested_version, used_fallback_resolution)`.
+    If `installed_core_meta_path` is not None, the caller should return it directly and
+    ignore the other two values.
+    """
+    if ext_path is None:
+        return None, "latest", True
+
+    resolved_ext_path = Path(ext_path).resolve()
+    installed_core_meta = _get_installed_core_meta(resolved_ext_path)
+    if installed_core_meta is not None:
+        return installed_core_meta, "", False
+
+    legacy_version = _legacy_builder_marker_version(resolved_ext_path)
+    if legacy_version is not None:
+        if logger:
+            logger.warning(
+                "\033[33m@jupyterlab/core-meta was not found in node_modules. This "
+                "extension declares a devDependency on %s@%s, which is a legacy package "
+                "so core-meta %s will be used instead of the latest release. "
+                " To avoid this, add @jupyter/builder as a devDependency instead "
+                "of %s.\n \033[0m",
+                _LEGACY_BUILDER_MARKER,
+                legacy_version,
+                legacy_version,
+                _LEGACY_BUILDER_MARKER,
+            )
+        return None, _normalize_version(legacy_version), False
+
+    if logger:
+        logger.warning(
+            "\033[33m@jupyterlab/core-meta was not found in node_modules, "
+            "so a network download will be used as a fallback. To avoid this, "
+            "add @jupyter/builder as a devDependency instead of "
+            "@jupyterlab/builder.\n \033[0m",
+        )
+    return None, "latest", True
+
+
+def _legacy_builder_marker_version(ext_path: Path) -> str | None:
+    """Return the extension's own pinned `@jupyterlab/builder` version, if declared.
+
+    Returns None if the marker isn't declared, the version is a local path/workspace
+    spec rather than a real version, or `package.json` can't be read.
+    """
+    try:
+        with (ext_path / "package.json").open() as fid:
+            ext_data = json.load(fid)
+    except (OSError, ValueError):
+        return None
+    version_spec = ext_data.get("devDependencies", {}).get(
+        _LEGACY_BUILDER_MARKER,
+    ) or ext_data.get("dependencies", {}).get(_LEGACY_BUILDER_MARKER)
+    if not isinstance(version_spec, str) or "/" in version_spec:
+        return None
+    version = re.sub(r"^[\^~<>=\s]+", "", version_spec)
+    return version if re.match(r"\d", version) else None
+
+
 def _normalize_version(version: str) -> str:
     """Strip a leading 'v' from a numeric version so 'vX.Y.Z' and 'X.Y.Z' are equivalent."""
     return version[1:] if re.match(r"v\d", version) else version
+
+
+def _major_minor(version: str) -> str | None:
+    match = re.match(r"\d+\.\d+", version)
+    return match.group(0) if match else None
+
+
+def _check_matches_installed_jupyterlab(
+    core_meta_version: str,
+    used_fallback_resolution: bool,
+    logger: logging.Logger | None = None,
+) -> None:
+    """Fail fast if a fallback-resolved core-meta version doesn't match installed jupyterlab."""
+    if not used_fallback_resolution:
+        return
+    try:
+        jupyterlab_version = installed_version("jupyterlab")
+    except PackageNotFoundError:
+        return
+    if _major_minor(core_meta_version) != _major_minor(jupyterlab_version):
+        msg = (
+            f"building against {core_meta_version} metadata but jupyterlab "
+            f"{jupyterlab_version} is installed"
+        )
+        if logger:
+            logger.error("\033[31m%s\n \033[0m", msg)
+        raise RuntimeError(msg)
 
 
 def _github_ref(version: str) -> str:

--- a/jupyter_builder/core_path.py
+++ b/jupyter_builder/core_path.py
@@ -21,6 +21,11 @@ _MAX_CORE_META_BYTES = 5 * 1024 * 1024  # 5 MB — generous upper bound for core
 #: GitHub API endpoint used to resolve wildcard versions to concrete release tags
 _GITHUB_TAGS_API_URL = "https://api.github.com/repos/jupyterlab/jupyterlab/tags"
 
+#: GitHub API endpoint used to resolve "latest" to the newest stable release
+_GITHUB_LATEST_RELEASE_API_URL = (
+    "https://api.github.com/repos/jupyterlab/jupyterlab/releases/latest"
+)
+
 #: Upper bound on tag-list pages fetched when resolving a wildcard (100 tags per page)
 _MAX_GITHUB_TAG_PAGES = 10
 
@@ -61,7 +66,7 @@ def get_core_meta(
                     "add @jupyter/builder as a devDependency instead of "
                     "@jupyterlab/builder.\n \033[0m",
                 )
-        requested_version = "main"
+        requested_version = "latest"
     else:
         # Accept both "vX.Y.Z" and "X.Y.Z" for an explicitly requested version.
         requested_version = _normalize_version(requested_version)
@@ -82,13 +87,7 @@ def get_core_meta(
         return str(npm_cache_file)
     except urllib.error.URLError as npm_error:
         try:
-            # Wildcards (e.g. "4.5.x") have no single git ref, so resolve them
-            # to a concrete tag from the GitHub tag list before downloading.
-            github_version = (
-                _resolve_wildcard_github_version(requested_version)
-                if _is_wildcard_version(requested_version)
-                else requested_version
-            )
+            github_version = _resolve_github_version(requested_version)
             github_cache_file = cache_root / github_version / "core.package.json"
             if github_cache_file.exists():
                 return str(github_cache_file)
@@ -189,6 +188,35 @@ def _semver_key(v: str) -> tuple[tuple[int, ...], int, tuple[int, ...]]:
     # order by the numeric identifiers (e.g. alpha.3 < alpha.4).
     pre_numeric = tuple(int(p) for p in prerelease.split(".") if p.isdigit())
     return (numeric, 0 if prerelease else 1, pre_numeric)
+
+
+def _resolve_github_version(version: str) -> str:
+    """Resolve an abstract version specifier to a concrete jupyterlab/jupyterlab git ref.
+
+    "latest" and wildcards (e.g. "4.5.x") have no single git ref, so they are resolved
+    to a concrete tag from the GitHub tag list. Anything else is returned as-is.
+    """
+    if version == "latest":
+        return _resolve_latest_github_version()
+    if _is_wildcard_version(version):
+        return _resolve_wildcard_github_version(version)
+    return version
+
+
+def _resolve_latest_github_version() -> str:
+    """Resolve the latest stable jupyterlab/jupyterlab release tag from GitHub.
+
+    Used as a fallback when npm cannot be reached to resolve the "latest" dist-tag.
+    GitHub's "latest release" already excludes prereleases and drafts, mirroring
+    npm's "latest" semantics.
+    """
+    data = _http_get(_GITHUB_LATEST_RELEASE_API_URL)
+    release = json.loads(data)
+    tag_name = release.get("tag_name") if isinstance(release, dict) else None
+    if not isinstance(tag_name, str) or not tag_name:
+        msg = "Failed to resolve latest jupyterlab/jupyterlab release from GitHub"
+        raise urllib.error.URLError(msg)
+    return _normalize_version(tag_name)
 
 
 def _resolve_wildcard_github_version(version: str) -> str:

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "watch": "tsc -w --sourceMap"
   },
   "dependencies": {
-    "@jupyterlab/core-meta": "4.6.1",
+    "@jupyterlab/core-meta": "^4.6.1",
     "@module-federation/runtime-tools": "^2.0.0",
     "@rspack/core": "^2.1.2",
     "ajv": "^8.12.0",

--- a/tests/test_core_path.py
+++ b/tests/test_core_path.py
@@ -471,6 +471,89 @@ def test_get_core_meta_latest_uses_npm_latest_and_caches_by_resolved_version(tmp
     )
 
 
+def test_get_core_meta_defaults_to_latest_when_not_installed(tmp_path, monkeypatch):
+    """With no explicit version and no installed core-meta, the npm "latest" dist-tag is used."""
+    ext_path = tmp_path / "ext"
+    ext_path.mkdir()
+    (ext_path / "node_modules").mkdir()
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    tarball_content = b'{"devDependencies": {}}'
+    tarball_bytes = _make_core_package_tarball(tarball_content)
+    tarball_url = f"{core_path.JPBLD_NPM_URL}/@jupyterlab/core-meta/-/core-meta-4.5.7.tgz"
+    registry_meta = json.dumps({"dist": {"tarball": tarball_url}}).encode()
+
+    calls = []
+
+    def fake_urlopen(req_or_url, **_kwargs):
+        url = getattr(req_or_url, "full_url", req_or_url)
+        calls.append(url)
+        if url == f"{core_path.JPBLD_NPM_URL}/@jupyterlab/core-meta/latest":
+            return io.BytesIO(json.dumps({"version": "4.5.7"}).encode())
+        if url == f"{core_path.JPBLD_NPM_URL}/@jupyterlab/core-meta/4.5.7":
+            return io.BytesIO(registry_meta)
+        if url == tarball_url:
+            return io.BytesIO(tarball_bytes)
+        msg = f"Unexpected URL {url}"
+        raise AssertionError(msg)
+
+    monkeypatch.setattr(core_path.urllib.request, "urlopen", fake_urlopen)
+
+    location = core_path.get_core_meta(ext_path=ext_path)
+
+    assert calls == [
+        f"{core_path.JPBLD_NPM_URL}/@jupyterlab/core-meta/latest",
+        f"{core_path.JPBLD_NPM_URL}/@jupyterlab/core-meta/4.5.7",
+        tarball_url,
+    ]
+    assert location == str(
+        tmp_path / ".cache" / "jupyterlab_builder" / "core" / "4.5.7" / "core.package.json",
+    )
+
+
+def test_get_core_meta_latest_falls_back_to_github_when_npm_unreachable(tmp_path, monkeypatch):
+    """If npm is unreachable, "latest" is resolved to the newest GitHub release tag."""
+    ext_path = tmp_path / "ext"
+    ext_path.mkdir()
+    (ext_path / "node_modules").mkdir()
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    github_url = (
+        "https://raw.githubusercontent.com/"
+        "jupyterlab/jupyterlab/v4.5.7/"
+        "jupyterlab/staging/package.json"
+    )
+    latest_release = json.dumps({"tag_name": "v4.5.7"}).encode()
+
+    calls = []
+
+    def fake_urlopen(req_or_url, **_kwargs):
+        url = getattr(req_or_url, "full_url", req_or_url)
+        calls.append(url)
+        if url == f"{core_path.JPBLD_NPM_URL}/@jupyterlab/core-meta/latest":
+            msg = "Not Found"
+            raise urllib.error.URLError(msg)
+        if url == core_path._GITHUB_LATEST_RELEASE_API_URL:
+            return io.BytesIO(latest_release)
+        if url == github_url:
+            return io.BytesIO(b'{"dependencies": {}}')
+        msg = f"Unexpected URL {url}"
+        raise AssertionError(msg)
+
+    monkeypatch.setattr(core_path.urllib.request, "urlopen", fake_urlopen)
+
+    location = core_path.get_core_meta(ext_path=ext_path)
+
+    assert calls == [
+        f"{core_path.JPBLD_NPM_URL}/@jupyterlab/core-meta/latest",
+        core_path._GITHUB_LATEST_RELEASE_API_URL,
+        github_url,
+    ]
+    assert location == str(
+        tmp_path / ".cache" / "jupyterlab_builder" / "core" / "4.5.7" / "core.package.json",
+    )
+
+
 def test_ensure_builder_with_jupyter_builder(tmp_path):
     ext_path = tmp_path / "ext"
     core_path_dir = tmp_path / "core-meta"

--- a/tests/test_core_path.py
+++ b/tests/test_core_path.py
@@ -3,9 +3,11 @@
 
 import io
 import json
+import re
 import tarfile
 import urllib.error
 from pathlib import Path
+from unittest import mock
 
 import pytest
 
@@ -24,6 +26,19 @@ def _make_core_package_tarball(content: bytes) -> bytes:
         info.size = len(content)
         tar.addfile(info, io.BytesIO(content))
     return buf.getvalue()
+
+
+@pytest.fixture(autouse=True)
+def _no_jupyterlab_installed(monkeypatch):
+    """Default to "jupyterlab is not installed" so tests are isolated from the dev environment.
+
+    Tests that exercise the fallback-version compatibility check override this.
+    """
+
+    def _raise_not_found(_package):
+        raise core_path.PackageNotFoundError(_package)
+
+    monkeypatch.setattr(core_path, "installed_version", _raise_not_found)
 
 
 def test_get_core_meta_prefers_installed_core_meta(tmp_path):
@@ -552,6 +567,223 @@ def test_get_core_meta_latest_falls_back_to_github_when_npm_unreachable(tmp_path
     assert location == str(
         tmp_path / ".cache" / "jupyterlab_builder" / "core" / "4.5.7" / "core.package.json",
     )
+
+
+def test_get_core_meta_fallback_raises_on_installed_jupyterlab_mismatch(tmp_path, monkeypatch):
+    """A fallback-resolved version whose major.minor disagrees with jupyterlab is rejected."""
+    ext_path = tmp_path / "ext"
+    ext_path.mkdir()
+    (ext_path / "node_modules").mkdir()
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setattr(core_path, "installed_version", lambda _package: "4.6.2")
+
+    def fake_urlopen(req_or_url, **_kwargs):
+        url = getattr(req_or_url, "full_url", req_or_url)
+        if url == f"{core_path.JPBLD_NPM_URL}/@jupyterlab/core-meta/latest":
+            return io.BytesIO(json.dumps({"version": "4.5.7"}).encode())
+        msg = f"Unexpected URL {url}"
+        raise AssertionError(msg)
+
+    monkeypatch.setattr(core_path.urllib.request, "urlopen", fake_urlopen)
+
+    with pytest.raises(RuntimeError, match=re.escape("building against 4.5.7 metadata")):
+        core_path.get_core_meta(ext_path=ext_path)
+
+
+def test_get_core_meta_fallback_allows_matching_installed_jupyterlab(tmp_path, monkeypatch):
+    """A fallback-resolved version is accepted when its major.minor matches jupyterlab."""
+    ext_path = tmp_path / "ext"
+    ext_path.mkdir()
+    (ext_path / "node_modules").mkdir()
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setattr(core_path, "installed_version", lambda _package: "4.5.0")
+
+    tarball_content = b'{"devDependencies": {}}'
+    tarball_bytes = _make_core_package_tarball(tarball_content)
+    tarball_url = f"{core_path.JPBLD_NPM_URL}/@jupyterlab/core-meta/-/core-meta-4.5.7.tgz"
+    registry_meta = json.dumps({"dist": {"tarball": tarball_url}}).encode()
+
+    def fake_urlopen(req_or_url, **_kwargs):
+        url = getattr(req_or_url, "full_url", req_or_url)
+        if url == f"{core_path.JPBLD_NPM_URL}/@jupyterlab/core-meta/latest":
+            return io.BytesIO(json.dumps({"version": "4.5.7"}).encode())
+        if url == f"{core_path.JPBLD_NPM_URL}/@jupyterlab/core-meta/4.5.7":
+            return io.BytesIO(registry_meta)
+        if url == tarball_url:
+            return io.BytesIO(tarball_bytes)
+        msg = f"Unexpected URL {url}"
+        raise AssertionError(msg)
+
+    monkeypatch.setattr(core_path.urllib.request, "urlopen", fake_urlopen)
+
+    location = core_path.get_core_meta(ext_path=ext_path)
+
+    assert location == str(
+        tmp_path / ".cache" / "jupyterlab_builder" / "core" / "4.5.7" / "core.package.json",
+    )
+
+
+def test_get_core_meta_explicit_version_skips_installed_jupyterlab_check(tmp_path, monkeypatch):
+    """An explicitly requested version is trusted even if it disagrees with jupyterlab."""
+    ext_path = tmp_path / "ext"
+    core_meta_dir = tmp_path / "core-meta"
+    core_meta_dir.mkdir()
+    (core_meta_dir / "core.package.json").write_text('{"devDependencies": {}}')
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setattr(core_path, "installed_version", lambda _package: "4.6.2")
+
+    cache_file = tmp_path / ".cache" / "jupyterlab_builder" / "core" / "4.5.7" / "core.package.json"
+    cache_file.parent.mkdir(parents=True)
+    cache_file.write_text('{"devDependencies": {}}')
+
+    location = core_path.get_core_meta(version="4.5.7", ext_path=ext_path)
+
+    assert location == str(cache_file)
+
+
+def test_get_core_meta_resolves_to_legacy_builder_marker_version(tmp_path, monkeypatch):
+    """With no installed core-meta, a legacy @jupyterlab/builder pin is used over "latest"."""
+    ext_path = tmp_path / "ext"
+    ext_path.mkdir()
+    (ext_path / "node_modules").mkdir()
+    (ext_path / "package.json").write_text(
+        json.dumps({"devDependencies": {"@jupyterlab/builder": "^4.5.7"}}),
+    )
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    tarball_content = b'{"devDependencies": {}}'
+    tarball_bytes = _make_core_package_tarball(tarball_content)
+    tarball_url = f"{core_path.JPBLD_NPM_URL}/@jupyterlab/core-meta/-/core-meta-4.5.7.tgz"
+    registry_meta = json.dumps({"dist": {"tarball": tarball_url}}).encode()
+
+    calls = []
+
+    def fake_urlopen(req_or_url, **_kwargs):
+        url = getattr(req_or_url, "full_url", req_or_url)
+        calls.append(url)
+        if url == f"{core_path.JPBLD_NPM_URL}/@jupyterlab/core-meta/4.5.7":
+            return io.BytesIO(registry_meta)
+        if url == tarball_url:
+            return io.BytesIO(tarball_bytes)
+        msg = f"Unexpected URL {url}"
+        raise AssertionError(msg)
+
+    monkeypatch.setattr(core_path.urllib.request, "urlopen", fake_urlopen)
+    logger = mock.Mock()
+
+    location = core_path.get_core_meta(ext_path=ext_path, logger=logger)
+
+    # The "latest" dist-tag is never hit — the marker's own version is requested directly.
+    assert calls == [
+        f"{core_path.JPBLD_NPM_URL}/@jupyterlab/core-meta/4.5.7",
+        tarball_url,
+    ]
+    assert location == str(
+        tmp_path / ".cache" / "jupyterlab_builder" / "core" / "4.5.7" / "core.package.json",
+    )
+    logger.warning.assert_called_once()
+    warning_message = logger.warning.call_args[0][0] % logger.warning.call_args[0][1:]
+    assert "@jupyterlab/builder@4.5.7" in warning_message
+
+
+def test_get_core_meta_legacy_builder_marker_skips_installed_jupyterlab_check(
+    tmp_path,
+    monkeypatch,
+):
+    """A legacy-marker-resolved version is trusted like an explicit version, not a guess."""
+    ext_path = tmp_path / "ext"
+    ext_path.mkdir()
+    (ext_path / "node_modules").mkdir()
+    (ext_path / "package.json").write_text(
+        json.dumps({"devDependencies": {"@jupyterlab/builder": "^4.5.7"}}),
+    )
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setattr(core_path, "installed_version", lambda _package: "4.6.2")
+
+    tarball_content = b'{"devDependencies": {}}'
+    tarball_bytes = _make_core_package_tarball(tarball_content)
+    tarball_url = f"{core_path.JPBLD_NPM_URL}/@jupyterlab/core-meta/-/core-meta-4.5.7.tgz"
+    registry_meta = json.dumps({"dist": {"tarball": tarball_url}}).encode()
+
+    def fake_urlopen(req_or_url, **_kwargs):
+        url = getattr(req_or_url, "full_url", req_or_url)
+        if url == f"{core_path.JPBLD_NPM_URL}/@jupyterlab/core-meta/4.5.7":
+            return io.BytesIO(registry_meta)
+        if url == tarball_url:
+            return io.BytesIO(tarball_bytes)
+        msg = f"Unexpected URL {url}"
+        raise AssertionError(msg)
+
+    monkeypatch.setattr(core_path.urllib.request, "urlopen", fake_urlopen)
+
+    location = core_path.get_core_meta(ext_path=ext_path)
+
+    assert location == str(
+        tmp_path / ".cache" / "jupyterlab_builder" / "core" / "4.5.7" / "core.package.json",
+    )
+
+
+def test_get_core_meta_ignores_legacy_builder_marker_workspace_spec(tmp_path, monkeypatch):
+    """A path/workspace version spec isn't a real version, so it falls through to "latest"."""
+    ext_path = tmp_path / "ext"
+    ext_path.mkdir()
+    (ext_path / "node_modules").mkdir()
+    (ext_path / "package.json").write_text(
+        json.dumps({"devDependencies": {"@jupyterlab/builder": "file:../builder"}}),
+    )
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    tarball_content = b'{"devDependencies": {}}'
+    tarball_bytes = _make_core_package_tarball(tarball_content)
+    tarball_url = f"{core_path.JPBLD_NPM_URL}/@jupyterlab/core-meta/-/core-meta-4.5.7.tgz"
+    registry_meta = json.dumps({"dist": {"tarball": tarball_url}}).encode()
+
+    def fake_urlopen(req_or_url, **_kwargs):
+        url = getattr(req_or_url, "full_url", req_or_url)
+        if url == f"{core_path.JPBLD_NPM_URL}/@jupyterlab/core-meta/latest":
+            return io.BytesIO(json.dumps({"version": "4.5.7"}).encode())
+        if url == f"{core_path.JPBLD_NPM_URL}/@jupyterlab/core-meta/4.5.7":
+            return io.BytesIO(registry_meta)
+        if url == tarball_url:
+            return io.BytesIO(tarball_bytes)
+        msg = f"Unexpected URL {url}"
+        raise AssertionError(msg)
+
+    monkeypatch.setattr(core_path.urllib.request, "urlopen", fake_urlopen)
+
+    location = core_path.get_core_meta(ext_path=ext_path)
+
+    assert location == str(
+        tmp_path / ".cache" / "jupyterlab_builder" / "core" / "4.5.7" / "core.package.json",
+    )
+
+
+@pytest.mark.parametrize(
+    ("version_spec", "expected"),
+    [
+        ("4.5.7", "4.5.7"),
+        ("^4.5.7", "4.5.7"),
+        ("~4.5.7", "4.5.7"),
+        (">=4.5.7", "4.5.7"),
+        ("file:../builder", None),
+        ("workspace:*", None),
+    ],
+)
+def test_legacy_builder_marker_version_parses_spec(tmp_path, version_spec, expected):
+    ext_path = tmp_path / "ext"
+    ext_path.mkdir()
+    (ext_path / "package.json").write_text(
+        json.dumps({"devDependencies": {"@jupyterlab/builder": version_spec}}),
+    )
+
+    assert core_path._legacy_builder_marker_version(ext_path) == expected
+
+
+def test_legacy_builder_marker_version_none_without_package_json(tmp_path):
+    ext_path = tmp_path / "ext"
+    ext_path.mkdir()
+
+    assert core_path._legacy_builder_marker_version(ext_path) is None
 
 
 def test_ensure_builder_with_jupyter_builder(tmp_path):

--- a/yarn.lock
+++ b/yarn.lock
@@ -193,7 +193,7 @@ __metadata:
   resolution: "@jupyter/builder@workspace:."
   dependencies:
     "@eslint/js": ^10.0.1
-    "@jupyterlab/core-meta": 4.6.1
+    "@jupyterlab/core-meta": ^4.6.1
     "@module-federation/runtime-tools": ^2.0.0
     "@rspack/core": ^2.1.2
     "@types/fs-extra": ^9.0.1
@@ -225,10 +225,10 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@jupyterlab/core-meta@npm:4.6.1":
-  version: 4.6.1
-  resolution: "@jupyterlab/core-meta@npm:4.6.1"
-  checksum: 8f91135b66806b65db81c4371dae36f794b476a869810b2c99ac243a94fc6a55a392a2dfbb2a93b5c225f4f45b5f50e43fa5641e68d15fa71db3c570cead161d
+"@jupyterlab/core-meta@npm:^4.6.1":
+  version: 4.6.2
+  resolution: "@jupyterlab/core-meta@npm:4.6.2"
+  checksum: d38054d6f4a5376d4a8ee79b4771050d6e48104632f662a2003451bda5c0f84cc2ebbca0405a4d3dff938460e9b684f3581562a465dc4243758d0c8e44c8f559
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Fixes #152 

### Summary

This PR makes three small improvements to how `get_core_meta` selects a JupyterLab version when the caller does not explicitly provide one.

1. **Use the latest stable release instead of `main` by default**
   - It now resolves `"latest"` using npm's `latest` dist-tag, with GitHub's `releases/latest` API as a fallback.

2. **Fail fast when fallback version resolution is incompatible**
   - When no version, `ext_path`, or `core-meta` is provided and `get_core_meta` has to infer a version, it now validates the resolved version against the installed JupyterLab (if present).
   - If their `major.minor` versions do not match, the build now fails immediately instead of proceeding with incompatible metadata. For example, I got this when I removed `jupyterlab/core-meta` from node modules and initiated the build in the environment where I have older version of juptyerlab:
   

    <img width="725" height="142" alt="Screenshot 2026-07-28 at 13 31 43" src="https://github.com/user-attachments/assets/09ca72f7-f8af-49e3-a824-ca062777a336" />
    
   - This check only applies to inferred versions. Explicitly requested versions remain unchanged, so cross-compiling against a different JupyterLab version is still supported.

3. **Resolve legacy `@jupyterlab/builder` extensions correctly**
   - Now `get_core_meta` resolves the core metadata version from the extension's pinned `@jupyterlab/builder` dependency instead of using "latest" core metadata.
   - A warning is emitted explaining the behaviour and encouraging migration to `@jupyter/builder`.