### PR TITLE
Make module federation version configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,13 +57,14 @@ jlpm build
 <details>
 <summary><code>build</code></summary>
 
-| Flag                         | Description                                                            |
-| ---------------------------- | ---------------------------------------------------------------------- |
-| `--development`              | Build in development mode (default: `False`)                           |
-| `--source-map`               | Generate source maps (default: `False`)                                |
-| `--static-url=<url>`         | Set the URL for static assets                                          |
-| `--core-version=<version>`   | JupyterLab core version to build against                               |
-| `--core-package-file=<path>` | Path to a core application `package.json` (overrides `--core-version`) |
+| Flag                                 | Description                                                                                       |
+| ------------------------------------ | ------------------------------------------------------------------------------------------------- |
+| `--development`                      | Build in development mode (default: `False`)                                                      |
+| `--source-map`                       | Generate source maps (default: `False`)                                                           |
+| `--static-url=<url>`                 | Set the URL for static assets                                                                     |
+| `--core-version=<version>`           | JupyterLab core version to build against                                                          |
+| `--core-package-file=<path>`         | Path to a core application `package.json` (overrides `--core-version`)                            |
+| `--module-federation-version=<1\|2>` | Module Federation runtime version (default: `1`, see [below](#module-federation-runtime-version)) |
 
 </details>
 
@@ -82,12 +83,13 @@ jlpm build
 <details>
 <summary><code>watch</code></summary>
 
-| Flag                         | Description                                                            |
-| ---------------------------- | ---------------------------------------------------------------------- |
-| `--development`              | Build in development mode (default: `True`)                            |
-| `--source-map`               | Generate source maps (default: `False`)                                |
-| `--core-version=<version>`   | JupyterLab core version to build against                               |
-| `--core-package-file=<path>` | Path to a core application `package.json` (overrides `--core-version`) |
+| Flag                                 | Description                                                                                       |
+| ------------------------------------ | ------------------------------------------------------------------------------------------------- |
+| `--development`                      | Build in development mode (default: `True`)                                                       |
+| `--source-map`                       | Generate source maps (default: `False`)                                                           |
+| `--core-version=<version>`           | JupyterLab core version to build against                                                          |
+| `--core-package-file=<path>`         | Path to a core application `package.json` (overrides `--core-version`)                            |
+| `--module-federation-version=<1\|2>` | Module Federation runtime version (default: `1`, see [below](#module-federation-runtime-version)) |
 
 </details>
 
@@ -107,6 +109,7 @@ build_labextension(
     static_url=None,
     core_version=None,
     core_package_file=None,
+    module_federation_version=None,
 )
 
 develop_labextension_py(
@@ -122,8 +125,45 @@ watch_labextension(
     labextensions_path=[...],
     development=True,
     source_map=False,
+    module_federation_version=None,
 )
 ```
+
+### Module Federation runtime version
+
+Extensions are built with **Module Federation 1** — the webpack-compatible runtime — by
+default. Module Federation 2 can be opted into per build:
+
+```bash
+jupyter-builder build --module-federation-version 2 /path/to/extension
+```
+
+or per extension, in the extension's `package.json`:
+
+```json
+{
+  "jupyterlab": {
+    "moduleFederationVersion": 2
+  }
+}
+```
+
+The `--module-federation-version` flag takes precedence over the `package.json` value; if
+neither is set the default of `1` applies.
+
+**Why 2 is opt-in.** JupyterLab shares its core packages with `import: false`, meaning no
+fallback copy is bundled into the extension. For core packages that are *not* listed in
+JupyterLab's `singletonPackages` — `@jupyterlab/docregistry`, for example — the MF2 runtime
+fails hard when no version in the share scope satisfies the extension's `requiredVersion`,
+because there is no bundled fallback to fall back to. MF1 keeps webpack's behaviour of
+warning and using whatever version the host provides, which is what allows an extension
+built against one JupyterLab minor version to load in the next.
+
+Until that gap is closed upstream
+([module-federation/core#4651](https://github.com/module-federation/core/issues/4651)),
+version 2 is only safe for extensions that do not consume such packages. Setting it is a
+good way to test whether MF2 works for your extension, but MF1 remains the supported
+default.
 
 ### Environment variables
 

--- a/jupyter_builder/extension_commands/build.py
+++ b/jupyter_builder/extension_commands/build.py
@@ -48,6 +48,16 @@ class BuildLabExtensionApp(BaseExtensionApp):
         ),
     )
 
+    module_federation_version = Unicode(
+        "",
+        config=True,
+        help=(
+            "Module Federation runtime version to build with, either '1' or '2' "
+            "(default: '1'). Takes precedence over the extension's "
+            "jupyterlab.moduleFederationVersion."
+        ),
+    )
+
     aliases = {  # noqa: RUF012
         "static-url": "BuildLabExtensionApp.static_url",
         "development": "BuildLabExtensionApp.development",
@@ -55,6 +65,7 @@ class BuildLabExtensionApp(BaseExtensionApp):
         "core-package-file": "BuildLabExtensionApp.core_package_file",
         "core-path": "BuildLabExtensionApp.core_path",
         "core-version": "BuildLabExtensionApp.core_version",
+        "module-federation-version": "BuildLabExtensionApp.module_federation_version",
     }
 
     def run_task(self) -> None:
@@ -69,6 +80,7 @@ class BuildLabExtensionApp(BaseExtensionApp):
             core_version=self.core_version or None,
             core_package_file=self.core_package_file or None,
             core_path=self.core_path or None,
+            module_federation_version=self.module_federation_version or None,
         )
 
 

--- a/jupyter_builder/extension_commands/watch.py
+++ b/jupyter_builder/extension_commands/watch.py
@@ -40,11 +40,22 @@ class WatchLabExtensionApp(BaseExtensionApp):
         ),
     )
 
+    module_federation_version = Unicode(
+        "",
+        config=True,
+        help=(
+            "Module Federation runtime version to build with, either '1' or '2' "
+            "(default: '1'). Takes precedence over the extension's "
+            "jupyterlab.moduleFederationVersion."
+        ),
+    )
+
     aliases = {  # noqa: RUF012
         "core-package-file": "WatchLabExtensionApp.core_package_file",
         "development": "WatchLabExtensionApp.development",
         "source-map": "WatchLabExtensionApp.source_map",
         "core-version": "WatchLabExtensionApp.core_version",
+        "module-federation-version": "WatchLabExtensionApp.module_federation_version",
     }
 
     def run_task(self) -> None:
@@ -59,6 +70,7 @@ class WatchLabExtensionApp(BaseExtensionApp):
             source_map=self.source_map,
             core_version=self.core_version or None,
             core_package_file=self.core_package_file or None,
+            module_federation_version=self.module_federation_version or None,
         )
 
 

--- a/jupyter_builder/federated_extensions.py
+++ b/jupyter_builder/federated_extensions.py
@@ -215,9 +215,14 @@ def build_labextension(  # noqa: PLR0913
     core_version: str | None = None,
     core_package_file: str | None = None,
     core_path: str | None = None,
+    module_federation_version: str | int | None = None,
 ) -> None:
     """Build a labextension in the given path."""
     ext_path = str(Path(path).resolve())
+
+    module_federation_version = _normalize_module_federation_version(
+        module_federation_version,
+    )
 
     if core_path is not None:
         if logger:
@@ -247,8 +252,10 @@ def build_labextension(  # noqa: PLR0913
     else:
         core_flag = ["--core-package-file", core_package_file]
 
+    mf_flag = _module_federation_flag(module_federation_version, marker_pkg)
+
     node = _which_node_js()
-    arguments = [node, builder, *core_flag, ext_path]
+    arguments = [node, builder, *core_flag, *mf_flag, ext_path]
     if static_url is not None:
         arguments.extend(["--static-url", static_url])
     if development:
@@ -267,9 +274,15 @@ def watch_labextension(  # noqa: PLR0913
     source_map: bool = False,
     core_version: str | None = None,
     core_package_file: str | None = None,
+    module_federation_version: str | int | None = None,
 ) -> None:
     """Watch a labextension in a given path."""
     ext_path = str(Path(path).resolve())
+
+    module_federation_version = _normalize_module_federation_version(
+        module_federation_version,
+    )
+
     core_package_file = core_package_file or get_core_meta(
         core_version,
         ext_path=ext_path,
@@ -307,8 +320,10 @@ def watch_labextension(  # noqa: PLR0913
     else:
         core_flag = ["--core-package-file", core_package_file]
 
+    mf_flag = _module_federation_flag(module_federation_version, marker_pkg)
+
     node = _which_node_js()
-    arguments = [node, builder, *core_flag, "--watch", ext_path]
+    arguments = [node, builder, *core_flag, *mf_flag, "--watch", ext_path]
     if development:
         arguments.append("--development")
     if source_map:
@@ -325,6 +340,50 @@ def watch_labextension(  # noqa: PLR0913
 # Marker packages an extension may declare to identify its builder, in order
 # of preference.
 _BUILDER_MARKER_CANDIDATES = ("@jupyter/builder", "@jupyterlab/builder")
+
+# Module Federation runtime versions the builder can build against. Version 1
+# is the default and is applied by the builder itself, not here, so that an
+# extension's `jupyterlab.moduleFederationVersion` still applies when no
+# version is requested on the command line.
+_MODULE_FEDERATION_VERSIONS = ("1", "2")
+
+
+def _normalize_module_federation_version(value: str | int | None) -> str | None:
+    """Validate a requested Module Federation runtime version.
+
+    Returns the version as a string, or ``None`` when none was requested.
+    """
+    if value is None or value == "":
+        return None
+    normalized = str(value)
+    if normalized not in _MODULE_FEDERATION_VERSIONS:
+        msg = (
+            f"Invalid module_federation_version {value!r}: expected 1 or 2. "
+            "Version 1 (the default) is the webpack-compatible Module Federation "
+            "runtime; version 2 is experimental, see "
+            "https://github.com/module-federation/core/issues/4651"
+        )
+        raise ValueError(msg)
+    return normalized
+
+
+def _module_federation_flag(version: str | None, marker_pkg: str) -> list[str]:
+    """Return the builder flag selecting the Module Federation runtime version.
+
+    Empty when no version was requested, which leaves the choice to the
+    extension's `jupyterlab.moduleFederationVersion` and then the builder
+    default of 1.
+    """
+    if version is None:
+        return []
+    if marker_pkg != "@jupyter/builder":
+        msg = (
+            f"module_federation_version is only supported by @jupyter/builder, but "
+            f"this extension builds with {marker_pkg}, which has no such option."
+        )
+        raise ValueError(msg)
+    return ["--module-federation-version", version]
+
 
 # Minimum Node.js range required by `@rspack/core` when its own `engines.node`
 # field cannot be read. `@rspack/core` is a pure ES module that older Node.js

--- a/jupyter_builder/federated_extensions.py
+++ b/jupyter_builder/federated_extensions.py
@@ -360,8 +360,7 @@ def _normalize_module_federation_version(value: str | int | None) -> str | None:
         msg = (
             f"Invalid module_federation_version {value!r}: expected 1 or 2. "
             "Version 1 (the default) is the webpack-compatible Module Federation "
-            "runtime; version 2 is experimental, see "
-            "https://github.com/module-federation/core/issues/4651"
+            "runtime; version 2 is experimental"
         )
         raise ValueError(msg)
     return normalized

--- a/src/build-labextension.ts
+++ b/src/build-labextension.ts
@@ -59,8 +59,7 @@ function parseModuleFederationVersion(value: string): ModuleFederationVersion {
   if (value !== '1' && value !== '2') {
     throw new InvalidArgumentError(
       'Expected 1 or 2. Version 1 (the default) is the webpack-compatible ' +
-        'Module Federation runtime; version 2 is experimental, see ' +
-        'https://github.com/module-federation/core/issues/4651'
+        'Module Federation runtime; version 2 is experimental'
     );
   }
   return value === '1' ? 1 : 2;

--- a/src/build-labextension.ts
+++ b/src/build-labextension.ts
@@ -42,10 +42,29 @@
 ///////////////////////////////////////////////////////
 
 import * as path from 'path';
-import { program as commander } from 'commander';
+import { program as commander, InvalidArgumentError } from 'commander';
 import { type RspackError, MultiStats, rspack } from '@rspack/core';
-import generateConfig from './extensionConfig';
+import generateConfig, {
+  type ModuleFederationVersion
+} from './extensionConfig';
 import { stdout as colors } from 'supports-color';
+
+/**
+ * Parse the `--module-federation-version` flag.
+ *
+ * Only 1 and 2 are accepted. Unset is not the same as 1: it lets the
+ * extension's `jupyterlab.moduleFederationVersion` apply before the default.
+ */
+function parseModuleFederationVersion(value: string): ModuleFederationVersion {
+  if (value !== '1' && value !== '2') {
+    throw new InvalidArgumentError(
+      'Expected 1 or 2. Version 1 (the default) is the webpack-compatible ' +
+        'Module Federation runtime; version 2 is experimental, see ' +
+        'https://github.com/module-federation/core/issues/4651'
+    );
+  }
+  return value === '1' ? 1 : 2;
+}
 
 commander
   .description('Build an extension')
@@ -55,6 +74,12 @@ commander
   .option(
     '--static-url <url>',
     'url for build assets, if hosted outside the built extension'
+  )
+  .option(
+    '--module-federation-version <1|2>',
+    'Module Federation runtime version to build with, overriding the ' +
+      "extension's jupyterlab.moduleFederationVersion (default: 1)",
+    parseModuleFederationVersion
   )
   .option('--watch')
   .action(async (options, command) => {
@@ -68,7 +93,8 @@ commander
       mode,
       corePackageFile,
       staticUrl: options.staticUrl,
-      devtool
+      devtool,
+      moduleFederationVersion: options.moduleFederationVersion
     });
     const compiler = rspack(config);
 

--- a/src/extensionConfig.ts
+++ b/src/extensionConfig.ts
@@ -12,7 +12,10 @@ import Ajv from 'ajv';
 
 const baseConfig = require('./webpack.config.base');
 
-// Deliberately the V1 (webpack-compatible) plugin rather than
+// Both Module Federation plugins, selected per build by
+// `moduleFederationVersion` (see `resolveModuleFederationVersion`).
+//
+// V1 - the webpack-compatible plugin - is deliberately the default rather than
 // `rspack.container.ModuleFederationPlugin`, which uses the Module Federation
 // 2.0 runtime. MF2 resolves a shared package that is consumed with
 // `import: false` and `singleton: false` - which is how core packages absent
@@ -22,7 +25,46 @@ const baseConfig = require('./webpack.config.base');
 // back to. V1 keeps webpack's behaviour of warning and using whatever version
 // the host provides, which is what makes an extension built against one
 // JupyterLab minor loadable in the next.
-const { ModuleFederationPluginV1: ModuleFederationPlugin } = rspack.container;
+//
+// Version 2 opts into the MF2 runtime, and with it the MF2 feature set. It is
+// only safe for extensions that do not consume non-singleton shared packages
+// lacking a bundled fallback, so it stays opt-in until the upstream gap is
+// closed: https://github.com/module-federation/core/issues/4651
+const {
+  ModuleFederationPluginV1,
+  ModuleFederationPlugin: ModuleFederationPluginV2
+} = rspack.container;
+
+/**
+ * The Module Federation runtime version an extension is built against.
+ */
+export type ModuleFederationVersion = 1 | 2;
+
+/**
+ * The Module Federation runtime version used when neither the CLI nor the
+ * extension's `package.json` requests one.
+ */
+export const DEFAULT_MODULE_FEDERATION_VERSION: ModuleFederationVersion = 1;
+
+/**
+ * Resolve the Module Federation runtime version to build with.
+ */
+export function resolveModuleFederationVersion(
+  fromOptions?: ModuleFederationVersion,
+  fromPackageData?: unknown
+): ModuleFederationVersion {
+  const requested = fromOptions ?? fromPackageData;
+  if (requested === undefined || requested === null) {
+    return DEFAULT_MODULE_FEDERATION_VERSION;
+  }
+  if (requested === 1 || requested === 2) {
+    return requested;
+  }
+  console.error(
+    `Invalid moduleFederationVersion ${JSON.stringify(requested)}: expected 1 or 2.`
+  );
+  return process.exit(1);
+}
 
 type SharedConfig = {
   requiredVersion?: string;
@@ -38,6 +80,7 @@ export interface IOptions {
   staticUrl?: string;
   mode?: 'development' | 'production';
   devtool?: string;
+  moduleFederationVersion?: ModuleFederationVersion;
 }
 
 function generateConfig({
@@ -45,7 +88,11 @@ function generateConfig({
   corePackageFile = 'package.json',
   staticUrl = '',
   mode = 'production',
-  devtool = mode === 'development' ? 'source-map' : undefined
+  devtool = mode === 'development' ? 'source-map' : undefined,
+  // No default here: `undefined` means "not requested", which lets the
+  // extension's `package.json` have its say before the default is applied in
+  // `resolveModuleFederationVersion` below.
+  moduleFederationVersion: requestedModuleFederationVersion
 }: IOptions = {}): rspack.Configuration[] {
   const data = require(path.join(packagePath, 'package.json'));
 
@@ -56,6 +103,12 @@ function generateConfig({
     console.error(validate.errors);
     process.exit(1);
   }
+
+  // The CLI flag wins over the extension's `package.json`.
+  const moduleFederationVersion = resolveModuleFederationVersion(
+    requestedModuleFederationVersion,
+    data.jupyterlab['moduleFederationVersion']
+  );
 
   const outputPath = path.join(packagePath, data.jupyterlab['outputDir']);
   const staticPath = path.join(outputPath, 'static');
@@ -246,6 +299,12 @@ function generateConfig({
       webpackConfig = require(webpackConfigPath);
     }
   }
+
+  // Version 1 unless the build explicitly opted into the MF2 runtime;
+  const ModuleFederationPlugin =
+    moduleFederationVersion === 2
+      ? ModuleFederationPluginV2
+      : ModuleFederationPluginV1;
 
   const plugins: NonNullable<rspack.Configuration['plugins']> = [
     new ModuleFederationPlugin({

--- a/src/metadata_schema.json
+++ b/src/metadata_schema.json
@@ -97,6 +97,11 @@
       "$ref": "#/definitions/relativePath",
       "default": null
     },
+    "moduleFederationVersion": {
+      "title": "Module Federation runtime version",
+      "description": "The Module Federation runtime version to build with. Defaults to 1, the webpack-compatible runtime, which warns and uses the host's version when a shared package falls outside requiredVersion. Version 2 is opt-in: its runtime instead fails hard for shared packages that are not singletons and have no bundled fallback (e.g. @jupyterlab/docregistry), which breaks loading across JupyterLab minor versions. See https://github.com/module-federation/core/issues/4651. Overridden by the --module-federation-version CLI flag.",
+      "enum": [1, 2]
+    },
     "sharedPackages": {
       "description": "Modules that should be shared in the share scope. When provided, property names are used to match requested modules in this compilation.",
       "ref": "#/definitions/sharedObject"

--- a/src/metadata_schema.json
+++ b/src/metadata_schema.json
@@ -99,8 +99,7 @@
     },
     "moduleFederationVersion": {
       "title": "Module Federation runtime version",
-      "description": "The Module Federation runtime version to build with. Defaults to 1, the webpack-compatible runtime, which warns and uses the host's version when a shared package falls outside requiredVersion. Version 2 is opt-in: its runtime instead fails hard for shared packages that are not singletons and have no bundled fallback (e.g. @jupyterlab/docregistry), which breaks loading across JupyterLab minor versions. See https://github.com/module-federation/core/issues/4651. Overridden by the --module-federation-version CLI flag.",
-      "enum": [1, 2]
+      "description": "The Module Federation runtime version to build with. Defaults to 1."
     },
     "sharedPackages": {
       "description": "Modules that should be shared in the share scope. When provided, property names are used to match requested modules in this compilation.",


### PR DESCRIPTION
## Make the Module Federation version configurable

MF1 was hardcoded in `extensionConfig.ts` by #155. This makes the MF1/MF2 choice an option, **defaulting to MF1**.

### New flag

| Layer | Option |
| --- | --- |
| CLI (`build`, `watch`) | `--module-federation-version=<1\|2>` |
| Extension `package.json` | `jupyterlab.moduleFederationVersion: 1 \| 2` |
| Python API | `build_labextension(..., module_federation_version=None)` (same for `watch_labextension`) |
| Node builder | `generateConfig({ moduleFederationVersion })` |

Invalid values are rejected with a clear error; the option is refused outright for the legacy `@jupyterlab/builder` marker, which has no such flag.