### PR TITLE
Support partial version specifiers (`4`, `4.5`)

### DIFF
--- a/jupyter_builder/core_path.py
+++ b/jupyter_builder/core_path.py
@@ -34,6 +34,10 @@ _MAX_GITHUB_TAG_PAGES = 10
 #: Pre-migration marker package.
 _LEGACY_BUILDER_MARKER = "@jupyterlab/builder"
 
+#: A version specifier built only from numeric and wildcard components, e.g. "4",
+#: "4.5", "4.x" or "4.5.*". These are npm ranges rather than concrete versions.
+_NUMERIC_OR_WILDCARD_SPEC = re.compile(r"[\dxX*]+(?:\.[\dxX*]+)*")
+
 
 def _home_dir() -> Path:
     home = os.environ.get("HOME")
@@ -59,8 +63,9 @@ def get_core_meta(
 ) -> str:
     """Return the path to the core package JSON, downloading it if needed."""
     if version is not None:
-        # Accept both "vX.Y.Z" and "X.Y.Z" for an explicitly requested version.
-        requested_version = _normalize_version(version)
+        # Accept both "vX.Y.Z" and "X.Y.Z" for an explicitly requested version, as
+        # well as partial specifiers such as "4" or "4.5".
+        requested_version = _expand_partial_version(_normalize_version(version))
         used_fallback_resolution = False
     else:
         installed_core_meta, requested_version, used_fallback_resolution = (
@@ -136,7 +141,7 @@ def _resolve_version_without_installed_core_meta(
                 legacy_version,
                 _LEGACY_BUILDER_MARKER,
             )
-        return None, _normalize_version(legacy_version), False
+        return None, _expand_partial_version(_normalize_version(legacy_version)), False
 
     if logger:
         logger.warning(
@@ -171,6 +176,31 @@ def _legacy_builder_marker_version(ext_path: Path) -> str | None:
 def _normalize_version(version: str) -> str:
     """Strip a leading 'v' from a numeric version so 'vX.Y.Z' and 'X.Y.Z' are equivalent."""
     return version[1:] if re.match(r"v\d", version) else version
+
+
+def _expand_partial_version(version: str) -> str:
+    """Expand a partial npm version specifier into an explicit wildcard range.
+
+    npm treats an omitted trailing component as a wildcard, so "4" means 4.x.x and
+    "4.5" means 4.5.x. Such a specifier is not a concrete version, so neither the npm
+    registry nor a jupyterlab/jupyterlab git tag can be looked up with it directly;
+    expanding it to the wildcard form lets the range resolvers pick the highest
+    matching release instead. A bare wildcard ("*", "x") means "any version" and is
+    mapped to "latest". Concrete versions ("4.5.7", "4.6.0-alpha.4") and non-numeric
+    specifiers ("latest", "main") are returned unchanged.
+    """
+    if not _NUMERIC_OR_WILDCARD_SPEC.fullmatch(version):
+        return version
+    parts = ["x" if part in {"x", "X", "*"} else part for part in version.split(".")]
+    parts.extend(["x"] * (3 - len(parts)))
+    if parts[0] == "x":
+        return "latest"
+    # Anything following a wildcard component is unconstrained too, so "4.x.7"
+    # is really 4.x.x.
+    if "x" in parts:
+        first_wildcard = parts.index("x")
+        parts[first_wildcard:] = ["x"] * (len(parts) - first_wildcard)
+    return ".".join(parts)
 
 
 def _major_minor(version: str) -> str | None:

--- a/tests/test_core_path.py
+++ b/tests/test_core_path.py
@@ -236,6 +236,36 @@ def test_normalize_version_accepts_both_forms(version):
     assert core_path._normalize_version(version) == "4.5.7"
 
 
+@pytest.mark.parametrize(
+    ("version", "expected"),
+    [
+        # Partial specifiers are ranges over the omitted components.
+        ("4", "4.x.x"),
+        ("4.5", "4.5.x"),
+        # Partially wildcarded ranges are completed the same way.
+        ("4.x", "4.x.x"),
+        ("4.X", "4.x.x"),
+        ("4.*", "4.x.x"),
+        ("4.5.*", "4.5.x"),
+        ("4.5.X", "4.5.x"),
+        # Nothing is constrained after a wildcard component.
+        ("4.x.7", "4.x.x"),
+        # A bare wildcard means "any version".
+        ("*", "latest"),
+        ("x", "latest"),
+        # Concrete versions and non-numeric specifiers are left alone.
+        ("4.5.7", "4.5.7"),
+        ("4.5.x", "4.5.x"),
+        ("4.6.0-alpha.4", "4.6.0-alpha.4"),
+        ("latest", "latest"),
+        ("main", "main"),
+        ("some-branch", "some-branch"),
+    ],
+)
+def test_expand_partial_version(version, expected):
+    assert core_path._expand_partial_version(version) == expected
+
+
 def test_get_core_meta_falls_back_to_github_for_prerelease(tmp_path, monkeypatch):
     """An npm-style prerelease that npm lacks is fetched from the matching git tag."""
     ext_path = tmp_path / "ext"


### PR DESCRIPTION
## Fixes #158

## Description

Expand partial npm version specifiers to the wildcard form already supported by the existing range resolution logic, allowing them to resolve to the highest matching release instead of constructing invalid `M.N` URLs.

Specifically:

- `4.5` → `4.5.x`
- `4` → `4.x.x`
- `*` → `latest`

This applies to both:

- the explicit `--version` argument, and
- legacy `@jupyterlab/builder` pins such as `^4.5`.