### PR TITLE
Allow Node.js prereleases in the version check

### DIFF
--- a/jupyter_builder/federated_extensions.py
+++ b/jupyter_builder/federated_extensions.py
@@ -359,14 +359,24 @@ def _read_rspack_node_range(builder: str, ext_path: str) -> str:
 
 
 def _satisfies_allowing_prerelease(current: str, node_range: str) -> bool:
-    """Return whether ``current`` satisfies ``node_range``, counting prereleases."""
+    """Return whether ``current`` satisfies ``node_range``, counting prereleases.
+
+    A prerelease has to clear the comparators both as itself and as its release,
+    so it can neither reach under a lower bound nor slip beneath an upper one:
+    ``22.12.0-alpha.1`` sorts before the ``22.12.0`` it needs to be, and
+    ``21.0.0-alpha.1`` is only ``<21.0.0`` because 21 is excluded to begin with.
+    """
     try:
         range_ = make_range(node_range, loose=True)  # type: ignore[no-untyped-call]
         version = make_semver(current, loose=True)  # type: ignore[no-untyped-call]
     except Exception:  # noqa: BLE001
         return False
+    candidates = [version]
+    if version.prerelease:
+        release = f"{version.major}.{version.minor}.{version.patch}"
+        candidates.append(make_semver(release, loose=True))  # type: ignore[no-untyped-call]
     return any(
-        all(comparator.test(version) for comparator in comparator_set)
+        all(comparator.test(candidate) for candidate in candidates for comparator in comparator_set)
         for comparator_set in range_.set
     )
 

--- a/jupyter_builder/federated_extensions.py
+++ b/jupyter_builder/federated_extensions.py
@@ -33,7 +33,7 @@ else:
 from .commands import _test_overlap
 from .core_path import get_core_meta
 from .jlpm import _which_node_js
-from .jupyterlab_semver import clean, satisfies
+from .jupyterlab_semver import clean, make_range, make_semver
 
 DEPRECATED_ARGUMENT = object()
 
@@ -358,6 +358,19 @@ def _read_rspack_node_range(builder: str, ext_path: str) -> str:
     return _FALLBACK_NODE_RANGE
 
 
+def _satisfies_allowing_prerelease(current: str, node_range: str) -> bool:
+    """Return whether ``current`` satisfies ``node_range``, counting prereleases."""
+    try:
+        range_ = make_range(node_range, loose=True)  # type: ignore[no-untyped-call]
+        version = make_semver(current, loose=True)  # type: ignore[no-untyped-call]
+    except Exception:  # noqa: BLE001
+        return False
+    return any(
+        all(comparator.test(version) for comparator in comparator_set)
+        for comparator_set in range_.set
+    )
+
+
 def _check_node_version(
     builder: str,
     ext_path: str,
@@ -371,11 +384,11 @@ def _check_node_version(
     except (OSError, subprocess.CalledProcessError):
         return
     current = clean(raw, loose=True)  # type: ignore[no-untyped-call]
-    if current is None or satisfies(current, node_range, loose=True):  # type: ignore[no-untyped-call]
+    if current is None or _satisfies_allowing_prerelease(current, node_range):
         return
     msg = (
         f"Building this extension requires Node.js {node_range} (found {raw}). "
-        "Please upgrade Node.js."
+        "Please install a compatible Node.js version."
     )
     if logger:
         logger.error(msg)

--- a/tests/test_core_path.py
+++ b/tests/test_core_path.py
@@ -907,7 +907,9 @@ def test_check_node_version_raises_on_old_node(tmp_path, monkeypatch):
         # A prerelease of the oldest supported version predates it, so it is not.
         ("22.12.0-alpha.1", False),
         ("20.19.0-alpha.1", False),
-        # Prereleases must not widen the range itself.
+        # Prereleases must not widen the range itself, including under an
+        # upper bound: 21.0.0-alpha.1 is <21.0.0, but 21.0.0 is excluded.
+        ("21.0.0-alpha.1", False),
         ("21.7.3-alpha.1", False),
         ("18.20.8-alpha.1", False),
         # Stable versions keep behaving as before.

--- a/tests/test_core_path.py
+++ b/tests/test_core_path.py
@@ -16,6 +16,7 @@ from jupyter_builder.federated_extensions import (
     _check_node_version,
     _ensure_builder,
     _read_rspack_node_range,
+    _satisfies_allowing_prerelease,
 )
 
 
@@ -894,6 +895,33 @@ def test_check_node_version_raises_on_old_node(tmp_path, monkeypatch):
 
     with pytest.raises(RuntimeError, match=r"requires Node\.js .* \(found v18\.20\.8\)"):
         _check_node_version(str(ext_path), str(ext_path))
+
+
+@pytest.mark.parametrize(
+    ("version", "expected"),
+    [
+        # A prerelease of a version newer than the range is new enough to build.
+        ("26.8.0-alpha.0.0.0", True),
+        ("22.13.0-nightly1", True),
+        ("20.19.1-alpha.1", True),
+        # A prerelease of the oldest supported version predates it, so it is not.
+        ("22.12.0-alpha.1", False),
+        ("20.19.0-alpha.1", False),
+        # Prereleases must not widen the range itself.
+        ("21.7.3-alpha.1", False),
+        ("18.20.8-alpha.1", False),
+        # Stable versions keep behaving as before.
+        ("26.8.0", True),
+        ("22.12.0", True),
+        ("20.19.0", True),
+        ("21.7.3", False),
+        ("18.20.8", False),
+        # Unparsable versions are rejected.
+        ("not-a-version", False),
+    ],
+)
+def test_satisfies_allowing_prerelease(version, expected):
+    assert _satisfies_allowing_prerelease(version, "^20.19.0 || >=22.12.0") is expected
 
 
 def test_check_node_version_passes_on_supported_node(tmp_path, monkeypatch):


### PR DESCRIPTION
## Fixes #174

### Description
The Node.js version check now accepts prereleases. npm-style semver never matches a prerelease against a range written for stable releases, so any prerelease failed the check no matter how new — Node 26.8.0 shipped reporting itself as `v26.8.0-alpha.0.0.0` (nodejs/node#65566), and we errored saying "upgrade" from it.

Also reworded the message to "Please install a compatible Node.js version.", since "upgrade" was wrong here.