### PR TITLE
Fix flaky macOS CI tests by authenticating GitHub API calls

### DIFF
--- a/.github/workflows/builder-tests.yml
+++ b/.github/workflows/builder-tests.yml
@@ -13,6 +13,8 @@ defaults:
   run:
     shell: bash -eux {0}
 
+permissions:
+  contents: read
 
 jobs:
   build:

--- a/.github/workflows/builder-tests.yml
+++ b/.github/workflows/builder-tests.yml
@@ -13,8 +13,6 @@ defaults:
   run:
     shell: bash -eux {0}
 
-env:
-  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 jobs:
   build:
@@ -96,6 +94,8 @@ jobs:
         run: pip install -e ".[test,dev]"
       - name: Run the tests
         run: pytest --cov
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - uses: jupyterlab/maintainer-tools/.github/actions/upload-coverage@v1
 
   test_lint:

--- a/.github/workflows/builder-tests.yml
+++ b/.github/workflows/builder-tests.yml
@@ -13,6 +13,9 @@ defaults:
   run:
     shell: bash -eux {0}
 
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/downstream-tests.yml
+++ b/.github/workflows/downstream-tests.yml
@@ -3,6 +3,9 @@ name: Downstream Tests
 on:
   pull_request:
 
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
 jobs:
   downstream:
     runs-on: ubuntu-latest

--- a/.github/workflows/downstream-tests.yml
+++ b/.github/workflows/downstream-tests.yml
@@ -3,9 +3,6 @@ name: Downstream Tests
 on:
   pull_request:
 
-env:
-  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
 jobs:
   downstream:
     runs-on: ubuntu-latest

--- a/jupyter_builder/core_path.py
+++ b/jupyter_builder/core_path.py
@@ -51,6 +51,8 @@ def _http_get(url: str, *, headers: dict[str, str] | None = None, timeout: int =
     request_headers = {"User-Agent": "jupyter-builder"}
     if headers:
         request_headers.update(headers)
+    if url.startswith("https://api.github.com/") and os.environ.get("GITHUB_TOKEN"):
+        request_headers["Authorization"] = f"Bearer {os.environ['GITHUB_TOKEN']}"
     req = urllib.request.Request(url, headers=request_headers)  # noqa: S310
     with urllib.request.urlopen(req, timeout=timeout) as resp:  # noqa: S310
         return bytes(resp.read())


### PR DESCRIPTION
I looked into the flaky CI failures in test_watch_functionality_jupyterlab_builder and test_files_build_jupyterlab_builder, mainly seen on macOS runners.

The issue was caused by jupyter-builder making unauthenticated requests to the GitHub API when resolving the @jupyterlab/core-meta version. On shared GitHub Actions runners, these requests can hit GitHub's rate limit and return a 403: rate limit exceeded error, which makes the tests fail.

To fix this, I updated _http_get() to use the GITHUB_TOKEN when making requests to the GitHub API. I also exposed GITHUB_TOKEN in the builder and downstream test workflows.

This should prevent the rate-limit failures and make the CI tests more stable across different runners.